### PR TITLE
Clip LV to avoid NaNs

### DIFF
--- a/sbids/tasks/__init__.py
+++ b/sbids/tasks/__init__.py
@@ -1,2 +1,2 @@
-from sbids.tasks.lotkavolterra import lokta_volterra as lotka_volterra
+from sbids.tasks.lotkavolterra import lotka_volterra, lotka_volterra_y_bijector, lotka_volterra_theta_bijector
 from sbids.tasks.utils import get_samples_and_scores

--- a/sbids/tasks/lotkavolterra.py
+++ b/sbids/tasks/lotkavolterra.py
@@ -45,6 +45,7 @@ def lokta_volterra(y=None, ts=jnp.linspace(0,18.9,10)):
     
     # integrate dz/dt, the result will have shape N x 2
     x = odeint(_dz_dt, z, ts, theta, rtol=1e-6, atol=1e-5, mxstep=1000)
+    x = jnp.clip(x, 1e-10, 1e4) # clip to avoid nan
 
     # measured populations
     return numpyro.sample("y", dist.LogNormal(jnp.log(x), jnp.ones_like(x)*0.1), obs=y)

--- a/sbids/tasks/lotkavolterra.py
+++ b/sbids/tasks/lotkavolterra.py
@@ -1,6 +1,9 @@
 import jax.numpy as jnp
 from jax.experimental.ode import odeint
-from jax.random import PRNGKey
+from tensorflow_probability.substrates import jax as tfp
+tfd = tfp.distributions
+tfb = tfp.bijectors
+
 import numpyro
 import numpyro.distributions as dist
 
@@ -49,3 +52,15 @@ def lokta_volterra(y=None, ts=jnp.linspace(0,18.9,10)):
 
     # measured populations
     return numpyro.sample("y", dist.LogNormal(jnp.log(x), jnp.ones_like(x)*0.1), obs=y)
+
+# Defines some useful bijectors that normalize the output of the model to approximately Gaussian.
+lokta_volterra_y_bijector = tfb.Chain([ 
+                tfb.Scale(0.38), 
+                tfb.Invert(tfb.Softplus()),
+                tfb.Scale(0.021)
+                ])
+lokta_volterra_theta_bijector = tfb.Chain([
+                tfb.Scale(jnp.array([2.,2.,2.,2.])),
+                tfb.Shift(jnp.array([0.125,3,0.125,3])),
+                tfb.Log()
+                ])

--- a/sbids/tasks/lotkavolterra.py
+++ b/sbids/tasks/lotkavolterra.py
@@ -53,7 +53,7 @@ def lokta_volterra(y=None, ts=jnp.linspace(0,18.9,10)):
     # measured populations
     return numpyro.sample("y", dist.LogNormal(jnp.log(x), jnp.ones_like(x)*0.1), obs=y)
 
-# Defines some useful bijectors that normalize the output of the model to approximately Gaussian.
+# Defines some useful bijectors that normalize the output of the model to approximately Gaussian and unconstrained.
 lokta_volterra_y_bijector = tfb.Chain([ 
                 tfb.Scale(0.38), 
                 tfb.Invert(tfb.Softplus()),

--- a/sbids/tasks/lotkavolterra.py
+++ b/sbids/tasks/lotkavolterra.py
@@ -7,7 +7,7 @@ tfb = tfp.bijectors
 import numpyro
 import numpyro.distributions as dist
 
-__all__=["lokta_volterra", "lokta_volterra_y_bijector", "lokta_volterra_theta_bijector"]
+__all__=["lotka_volterra", "lotka_volterra_y_bijector", "lotka_volterra_theta_bijector"]
 
 def _dz_dt(z, t, theta):
     """
@@ -28,7 +28,7 @@ def _dz_dt(z, t, theta):
     return jnp.stack([du_dt, dv_dt])
 
 
-def lokta_volterra(y=None, ts=jnp.linspace(0,18.9,10)):
+def lotka_volterra(y=None, ts=jnp.linspace(0,18.9,10)):
     """
     Probabilistic model for the Lotka–Volterra system.
     :param int N: number of measurement times
@@ -54,12 +54,12 @@ def lokta_volterra(y=None, ts=jnp.linspace(0,18.9,10)):
     return numpyro.sample("y", dist.LogNormal(jnp.log(x), jnp.ones_like(x)*0.1), obs=y)
 
 # Defines some useful bijectors that normalize the output of the model to approximately Gaussian and unconstrained.
-lokta_volterra_y_bijector = tfb.Chain([ 
+lotka_volterra_y_bijector = tfb.Chain([ 
                 tfb.Scale(0.38), 
                 tfb.Invert(tfb.Softplus()),
                 tfb.Scale(0.021)
                 ])
-lokta_volterra_theta_bijector = tfb.Chain([
+lotka_volterra_theta_bijector = tfb.Chain([
                 tfb.Scale(jnp.array([2.,2.,2.,2.])),
                 tfb.Shift(jnp.array([0.125,3,0.125,3])),
                 tfb.Log()

--- a/sbids/tasks/lotkavolterra.py
+++ b/sbids/tasks/lotkavolterra.py
@@ -7,7 +7,7 @@ tfb = tfp.bijectors
 import numpyro
 import numpyro.distributions as dist
 
-__all__=["lokta_volterra"]
+__all__=["lokta_volterra", "lokta_volterra_y_bijector", "lokta_volterra_theta_bijector"]
 
 def _dz_dt(z, t, theta):
     """


### PR DESCRIPTION
As mentioned in #11 , our implementation of LV sometimes returned annoying NaNs, because the output of the ODE could reach 0, and then sampling from the log normal likelihood would blow up.

This small PR adds clipping to avoid that issue, fixes #11 