### PR TITLE
Create Galton Board simulator 

### DIFF
--- a/notebooks/NumpyroGaltonBoard.ipynb
+++ b/notebooks/NumpyroGaltonBoard.ipynb
@@ -1,0 +1,776 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "collapsed_sections": [],
+      "authorship_tag": "ABX9TyO+qa/OMB8cFX2KYsrQMgFr",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/Justinezgh/SBI-Diff-Simulator/blob/u%2FJustinezgh%2Fgaltonboard/notebooks/NumpyroGaltonBoard.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "WmIfE8KbI4za",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "e7a7a3e6-db8f-459c-d7f9-a30f868498d3"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "  Building wheel for goldmine (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[K     |████████████████████████████████| 292 kB 4.4 MB/s \n",
+            "\u001b[?25h"
+          ]
+        }
+      ],
+      "source": [
+        "!pip install --quiet git+https://github.com/Justinezgh/goldmine.git@setup\n",
+        "!pip install --quiet numpyro "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%pylab inline \n",
+        "import jax \n",
+        "import jax.numpy as jnp \n",
+        "from numpyro.handlers import seed, trace, condition\n",
+        "import numpyro.distributions as dist\n",
+        "\n",
+        "import tensorflow_probability as tfp; tfp = tfp.substrates.jax\n",
+        "tfd= tfp.distributions\n",
+        "\n",
+        "import logging\n",
+        "logger = logging.getLogger()\n",
+        "class CheckTypesFilter(logging.Filter):\n",
+        "    def filter(self, record):\n",
+        "        return \"check_types\" not in record.getMessage()\n",
+        "logger.addFilter(CheckTypesFilter())\n",
+        "\n",
+        "from goldmine.simulators.galton import GeneralizedGaltonBoard\n",
+        "from goldmine.simulate import simulate, main"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "jrJx90toJCzA",
+        "outputId": "9e586d3b-1b41-42bf-aeff-52f64d0e0be9"
+      },
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Populating the interactive namespace from numpy and matplotlib\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# simulator from mining gold github \n",
+        "\n",
+        "import autograd.numpy as np\n",
+        "import autograd as ag\n",
+        "\n",
+        "from goldmine.simulators.base import Simulator\n",
+        "from goldmine.various.functions import sigmoid\n",
+        "from goldmine.various.utils import check_random_state\n",
+        "from tqdm import tqdm\n",
+        "\n",
+        "prior = tfd.Uniform(-1, 0)\n",
+        "\n",
+        "class GeneralizedGaltonBoard(Simulator):\n",
+        "    \"\"\" Generalized Galton board example from arXiv:1805.XXXXX \"\"\"\n",
+        "\n",
+        "\n",
+        "    def __init__(self, n_rows=20, n_nails=31):\n",
+        "\n",
+        "        super().__init__()\n",
+        "\n",
+        "        self.n_rows = n_rows\n",
+        "        self.n_nails = n_nails\n",
+        "\n",
+        "        self.d_trace = ag.grad_and_aux(self.trace)  # for mining: calculate the gradient log_p_xz (the joint score)\n",
+        "\n",
+        "    def nail_positions(self, theta, level=None, nail=None):\n",
+        "\n",
+        "        level_rel = 1. * level / (self.n_rows - 1) #zv\n",
+        "        nail_rel = 2. * nail / (self.n_nails - 1) - 1. #zh\n",
+        "\n",
+        "        nail_positions = ((1. - np.sin(np.pi * level_rel)) * 0.5\n",
+        "                          + np.sin(np.pi * level_rel) * sigmoid(10 * theta * nail_rel))\n",
+        "\n",
+        "        return nail_positions\n",
+        "\n",
+        "    def threshold(self, theta, trace):\n",
+        "        begin, z = trace\n",
+        "        pos = begin\n",
+        "        level = 0\n",
+        "        for step in z:\n",
+        "            if step == 0: # going left\n",
+        "                if level % 2 == 0:\n",
+        "                    pos = pos\n",
+        "                else:\n",
+        "                    pos = pos - 1\n",
+        "            else: # going right\n",
+        "                if level % 2 == 0:\n",
+        "                    pos = pos + 1\n",
+        "                else:\n",
+        "                    pos = pos\n",
+        "            level += 1\n",
+        "        if level % 2 == 1:  # for odd rows, the first and last nails are constant\n",
+        "            if pos == 0:\n",
+        "                return 0.0\n",
+        "            elif pos == self.n_nails:\n",
+        "                return 1.0\n",
+        "        return self.nail_positions(theta, level, pos)\n",
+        "\n",
+        "    def trace(self, theta, u, theta_ref=None, score = 'density'):\n",
+        "\n",
+        "        # Run and mine gold\n",
+        "        # left/right decisions are based on value of theta_ref (which defaults to theta if None)\n",
+        "        # but log_pxz based on value of theta (needed for ratio)\n",
+        "\n",
+        "        if theta_ref is None:\n",
+        "            theta_ref = theta\n",
+        "\n",
+        "        begin = pos = self.n_nails // 2\n",
+        "        z = []\n",
+        "        pos_ = [float(pos)]\n",
+        "        log_ = []\n",
+        "\n",
+        "        log_p_xz = 0.0\n",
+        "\n",
+        "        while len(z) < self.n_rows :\n",
+        "            t_ref = self.threshold(theta_ref, (begin, z))\n",
+        "            t = self.threshold(theta, (begin, z))\n",
+        "\n",
+        "            level = len(z)\n",
+        "\n",
+        "            # going left\n",
+        "            if u[level] < t_ref or t_ref == 1.0:\n",
+        "                log_p_xz += np.log(t)\n",
+        "                log_.append(float(np.log(t)._value))\n",
+        "\n",
+        "                if level % 2 == 0:  # even rows\n",
+        "                    pos = pos\n",
+        "                else:  # odd rows\n",
+        "                    pos = pos - 1\n",
+        "\n",
+        "                z.append(0)\n",
+        "\n",
+        "            # going right\n",
+        "            else:\n",
+        "                log_p_xz += np.log(1. - t)\n",
+        "                log_.append(float(np.log(1. - t)._value))\n",
+        "\n",
+        "                if level % 2 == 0:\n",
+        "                    pos = pos + 1\n",
+        "                else:\n",
+        "                    pos = pos\n",
+        "\n",
+        "                z.append(1)\n",
+        "            pos_.append(float(pos))\n",
+        "\n",
+        "        x = pos\n",
+        "        log_p_theta = prior.log_prob(jnp.array(theta._value))\n",
+        "        if score == 'density':\n",
+        "          return log_p_xz + log_p_theta , (float(x), pos_, log_)\n",
+        "        if score == 'conditional':\n",
+        "          return log_p_xz , (float(x), pos_, log_) \n",
+        "\n",
+        "\n",
+        "    def rvs_score(self,\n",
+        "                  theta, theta_score,\n",
+        "                  n, random_state=None,\n",
+        "                  score = 'density'):\n",
+        "\n",
+        "        \"\"\" Draws samples x according to p(x|theta), augments them with joint score t(x, z | theta_score) \"\"\"\n",
+        "\n",
+        "        rng = check_random_state(random_state)\n",
+        "\n",
+        "        all_x = []\n",
+        "        all_t_xz = []\n",
+        "        all_pos = []\n",
+        "        all_log = []\n",
+        "\n",
+        "        for i in tqdm(range(n)):\n",
+        "            u = rng.rand(self.n_rows)\n",
+        "\n",
+        "            t_xz, (x, pos, log) = self.d_trace(theta_score, u, theta_ref=theta)\n",
+        "\n",
+        "            all_x.append(x)\n",
+        "            all_t_xz.append(t_xz)\n",
+        "            all_pos.append(pos)\n",
+        "            all_log.append(log)\n",
+        "\n",
+        "        all_x = np.array(all_x)\n",
+        "        all_t_xz = np.array(all_t_xz)\n",
+        "        all_pos = np.array(all_pos)\n",
+        "        all_log = np.array(all_log)\n",
+        "\n",
+        "        return all_x, all_t_xz, all_pos, all_log\n",
+        "\n",
+        "\n",
+        "    def theta_defaults(self, n_thetas=100, single_theta=False, random=True):\n",
+        "      return np.array([prior.sample(n_thetas, jax.random.PRNGKey(0))]).reshape([-1,1])\n",
+        "\n",
+        "\n",
+        "\n",
+        "\n",
+        "#! /usr/bin/env python\n",
+        "\n",
+        "# from __future__ import absolute_import, division, print_function\n",
+        "\n",
+        "import argparse\n",
+        "import logging\n",
+        "from os import sys, path\n",
+        "import autograd.numpy as np\n",
+        "\n",
+        "\n",
+        "try:\n",
+        "    from goldmine.various.look_up import create_simulator\n",
+        "    from goldmine.various.utils import general_init, create_missing_folders, get_size\n",
+        "    from goldmine.simulators.base import SimulatorException\n",
+        "except ImportError:\n",
+        "    if base_dir in sys.path:\n",
+        "        raise\n",
+        "    sys.path.append(base_dir)\n",
+        "    from goldmine.various.look_up import create_simulator\n",
+        "    from goldmine.various.utils import general_init, create_missing_folders, get_size\n",
+        "    from goldmine.simulators.base import SimulatorException\n",
+        "\n",
+        "\n",
+        "def simulate(simulator_name,\n",
+        "             sample_label,\n",
+        "             theta0=None,\n",
+        "             theta1=None,\n",
+        "             draw_from=None,\n",
+        "             single_theta=False,\n",
+        "             grid_sampling=False,\n",
+        "             generate_joint_ratio=True,\n",
+        "             generate_joint_score=True,\n",
+        "             checkpoint=False,\n",
+        "             n_thetas=1000,\n",
+        "             n_samples_per_theta=1000,\n",
+        "             random_state=None,\n",
+        "             continue_after_exceptions=True, \n",
+        "             score = 'density'):\n",
+        "    \"\"\"\n",
+        "    Draws sample from a simulator.\n",
+        "\n",
+        "    :param continue_after_exceptions:\n",
+        "    :param single_theta:\n",
+        "    :param grid_sampling:\n",
+        "    :param sample_label:\n",
+        "    :param simulator_name: Specifies the simulator. Currently supported are 'galton' and 'epidemiology'.\n",
+        "    :param theta0: None or ndarray that provides a list of theta0 values (the numerator of the likelihood ratio as well\n",
+        "                   as the score reference point). If None, load simulator defaults.\n",
+        "    :param theta1: None or ndarray that provides a list of theta1 values (the denominator of the likelihood ratio) with\n",
+        "                   same shape as theta0. If None, load simulator defaults.\n",
+        "    :param draw_from: list, either [0], [1], or None (= [0,1]). Determines whether theta0, theta1, or both are used for\n",
+        "                      the sampling.\n",
+        "    :param generate_joint_ratio: bool, whether to ask the simulator for the joint ratio (only if theta1 is given).\n",
+        "    :param generate_joint_score: bool, whether to ask the simulator for the joint score.\n",
+        "    :param checkpoint: bool, whether to use a checkpointed version of the simulator.\n",
+        "    :param n_thetas: int, number of thetas samples of theta0 is None and single_theta is False\n",
+        "    :param n_samples_per_theta: Number of samples per combination of theta0 and theta1.\n",
+        "    :param random_state: Numpy random state.\n",
+        "    \"\"\"\n",
+        "\n",
+        "    simulator = GeneralizedGaltonBoard(n_rows, n_nails) \n",
+        "\n",
+        "\n",
+        "    # Default thetas\n",
+        "    if theta0 is None:\n",
+        "        theta0 = simulator.theta_defaults(single_theta=single_theta,\n",
+        "                                                  n_thetas=n_thetas,\n",
+        "                                                  random=not grid_sampling)\n",
+        "\n",
+        "    # Check thetas\n",
+        "    has_theta1 = (theta1 is not None)\n",
+        "\n",
+        "    if has_theta1:\n",
+        "        if theta1.shape != theta0.shape:\n",
+        "            raise ValueError('theta0 and theta1 have different shapes: %s, %s', theta0.shape, theta1.shape)\n",
+        "        if draw_from is None:\n",
+        "            draw_from = [0, 1]\n",
+        "        if draw_from not in [[0], [1], [0, 1]]:\n",
+        "            raise ValueError('draw_from has value other than [0], [1], [0,1]: %s', draw_from)\n",
+        "\n",
+        "    else:\n",
+        "        theta1 = np.empty_like(theta0)\n",
+        "        theta1[:] = np.NaN\n",
+        "\n",
+        "        if generate_joint_ratio:\n",
+        "            logging.warning('Joint ratio requested, but theta1 not given -- will just generate joint score.')\n",
+        "        generate_joint_ratio = False\n",
+        "\n",
+        "        if draw_from is None:\n",
+        "            draw_from = [0]\n",
+        "        if draw_from not in [[0]]:\n",
+        "            raise ValueError('No theta1, and draw_from has value other than [0]: %s', draw_from)\n",
+        "\n",
+        "    n_samples_per_theta_and_draw = n_samples_per_theta // len(draw_from)\n",
+        "\n",
+        "    # Data to be generated\n",
+        "    all_theta0 = []\n",
+        "    all_theta1 = []\n",
+        "    all_x = []\n",
+        "    all_y = []\n",
+        "    all_pos = []\n",
+        "    all_log = []\n",
+        "    all_r_xz = []\n",
+        "    all_t_xz = []\n",
+        "    all_z_checkpoints = []\n",
+        "    all_r_xz_checkpoints = []\n",
+        "    all_t_xz_checkpoints = []\n",
+        "\n",
+        "    logging.info('Parameter points:')\n",
+        "    logging.info('  theta0 = %s', theta0)\n",
+        "    if has_theta1:\n",
+        "        logging.info('  theta1 = %s', theta1)\n",
+        "\n",
+        "    # Loop over thetas and run simulator\n",
+        "    n_simulations = len(list(zip(theta0, theta1)))\n",
+        "    n_verbose = max(n_simulations // 100, 1)\n",
+        "\n",
+        "    for i_simulation, (theta0_, theta1_) in enumerate(zip(theta0, theta1)):\n",
+        "\n",
+        "\n",
+        "        if (i_simulation + 1) % n_verbose == 0:\n",
+        "            logging.info('Starting simulation for parameter setup %s / %s: theta0 = %s, theta1 = %s', i_simulation + 1,\n",
+        "                         n_simulations, theta0_, theta1_)\n",
+        "        \n",
+        "        for y in draw_from:\n",
+        "\n",
+        "            t_xz = None\n",
+        "            r_xz = None\n",
+        "            z_checkpoints = None\n",
+        "            r_xz_checkpoints = None\n",
+        "            t_xz_checkpoints = None\n",
+        "\n",
+        "            try:\n",
+        "                if checkpoint and generate_joint_score:\n",
+        "                    x, t_xz, z_checkpoints, t_xz_checkpoints = simulator.rvs_score(\n",
+        "                        theta=theta0_,\n",
+        "                        theta_score=theta0_,\n",
+        "                        n=n_samples_per_theta_and_draw,\n",
+        "                        random_state=random_state,\n",
+        "                        score = score\n",
+        "                    )\n",
+        "                elif generate_joint_score:\n",
+        "                    x, t_xz, pos, log = simulator.rvs_score(\n",
+        "                        theta=theta0_,\n",
+        "                        theta_score=theta0_,\n",
+        "                        n=n_samples_per_theta_and_draw,\n",
+        "                        random_state=random_state,\n",
+        "                        score = score\n",
+        "                    )\n",
+        "\n",
+        "                all_theta0 += [theta0_] * n_samples_per_theta_and_draw\n",
+        "                all_theta1 += [theta1_] * n_samples_per_theta_and_draw\n",
+        "                all_x += list(x)\n",
+        "                all_pos += list(pos)\n",
+        "                all_log += list(log)\n",
+        "                all_y += [y] * n_samples_per_theta_and_draw\n",
+        "                if generate_joint_ratio:\n",
+        "                    all_r_xz += list(r_xz)\n",
+        "                if generate_joint_score:\n",
+        "                    all_t_xz += list(t_xz)\n",
+        "                if checkpoint and (generate_joint_ratio or generate_joint_score):\n",
+        "                    all_z_checkpoints += list(z_checkpoints)\n",
+        "                    if generate_joint_ratio:\n",
+        "                        all_r_xz_checkpoints += list(r_xz_checkpoints)\n",
+        "                    if generate_joint_score:\n",
+        "                        all_t_xz_checkpoints += list(t_xz_checkpoints)\n",
+        "\n",
+        "            except SimulatorException as e:\n",
+        "                logging.warning('Simulator raised exception: %s', e)\n",
+        "\n",
+        "                if continue_after_exceptions:\n",
+        "                    logging.info('Ignoring this parameter point and continuing with others.')\n",
+        "                else:\n",
+        "                    raise\n",
+        "\n",
+        "    all_theta0 = np.array(all_theta0)\n",
+        "    all_theta1 = np.array(all_theta1)\n",
+        "    all_x = np.array(all_x)\n",
+        "    all_y = np.array(all_y)\n",
+        "    if generate_joint_ratio:\n",
+        "        all_r_xz = np.array(all_r_xz)\n",
+        "    if generate_joint_score:\n",
+        "        all_t_xz = np.array(all_t_xz)\n",
+        "    if checkpoint and (generate_joint_ratio or generate_joint_score):\n",
+        "        all_z_checkpoints = np.array(all_z_checkpoints)\n",
+        "        if generate_joint_ratio:\n",
+        "            all_r_xz_checkpoints = np.array(all_r_xz_checkpoints)\n",
+        "        if generate_joint_score:\n",
+        "            all_t_xz_checkpoints = np.array(all_t_xz_checkpoints)\n",
+        "\n",
+        "\n",
+        "    return all_theta0, all_x, all_t_xz, all_pos, all_log"
+      ],
+      "metadata": {
+        "id": "aZhA6saoJOV1"
+      },
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "theta_0 = -0.8\n",
+        "theta_1 = -0.6\n",
+        "\n",
+        "n_nails=31\n",
+        "n_rows=20"
+      ],
+      "metadata": {
+        "id": "vMf-CqLiJm3_"
+      },
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "galton_rvs  = lambda theta :GeneralizedGaltonBoard().rvs_score(theta, theta, n=20000, random_state=1234)\n",
+        "\n",
+        "samples_0, score_0, pos_0, log_0 = galton_rvs(theta_0)\n",
+        "p_estimated_0, _ = np.histogram(samples_0, bins=n_nails, range=(0, n_nails), density=True)\n",
+        "\n",
+        "samples_1, score_1, pos_1, log_1 = galton_rvs(theta_1)\n",
+        "p_estimated_1, _ = np.histogram(samples_1, bins=n_nails, range=(0, n_nails), density=True)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "_HLySVM_J7ss",
+        "outputId": "400ff074-1f87-4f9a-c0b4-1f2cecf20505"
+      },
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "100%|██████████| 20000/20000 [03:29<00:00, 95.42it/s] \n",
+            "100%|██████████| 20000/20000 [03:23<00:00, 98.24it/s] \n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# numpyro version \n",
+        "\n",
+        "import numpyro\n",
+        "import jax\n",
+        "from numpyro.handlers import seed, trace, condition\n",
+        "import numpyro.distributions as dist\n",
+        "import jax.numpy as jnp\n",
+        "from numpyro.contrib.control_flow import cond\n",
+        "\n",
+        "def sigmoid_(x):\n",
+        "    return 1. / (1. + jnp.exp(-x))\n",
+        "\n",
+        "def nail_positions(theta, n_rows, n_nails, level, nail):\n",
+        "\n",
+        "    level_rel = 1. * level / (n_rows - 1) #zv\n",
+        "    nail_rel = 2. * nail / (n_nails - 1) - 1. #zh\n",
+        "\n",
+        "    nail_positions = ((1. - jnp.sin(jnp.pi * level_rel)) * 0.5\n",
+        "                      + jnp.sin(jnp.pi * level_rel) * sigmoid_(10 * theta * nail_rel))\n",
+        "    \n",
+        "    res = cond(level % 2 == 1 and nail == 0, \n",
+        "                       lambda _: 0.0, \n",
+        "                       lambda _: cond(level % 2 == 1 and nail == n_nails, \n",
+        "                                                 lambda _: 1.0, \n",
+        "                                                 lambda _: nail_positions, \n",
+        "                                                 0), \n",
+        "                       0)\n",
+        "\n",
+        "    return nail_positions\n",
+        "\n",
+        "def galton_board(y = None,  n_rows = 20, n_nails = 31):\n",
+        "\n",
+        "  theta = numpyro.sample('theta', dist.Uniform(-1, 0))\n",
+        "  pos = n_nails // 2\n",
+        "\n",
+        "  for level in range(n_rows):\n",
+        "    # z = numpyro.sample('z%d' %level, dist.Bernoulli(1 - nail_positions(theta, n_rows, n_nails, level, pos)))\n",
+        "    # pos = z - (level % 2) + pos\n",
+        "    # print('level : ', level, '__pos :', pos, 'right :', jnp.log(1 - nail_positions(theta, n_rows, n_nails, level, pos)), 'left :', jnp.log(nail_positions(theta, n_rows, n_nails, level, pos)))\n",
+        "    \n",
+        "    pos = numpyro.sample('z%d' %level,  \n",
+        "                      dist.TransformedDistribution(dist.Bernoulli(1 - nail_positions(theta, n_rows, n_nails, level, pos)), \n",
+        "                                              dist.transforms.AffineTransform( - (level % 2) + pos, 1)))\n",
+        "    \n",
+        "  y = numpyro.sample(\"y\", \n",
+        "                      dist.TransformedDistribution(dist.Bernoulli(1 - nail_positions(theta, n_rows, n_nails, level, pos)), \n",
+        "                                              dist.transforms.AffineTransform( - (level % 2) + pos, 1)), \n",
+        "                      obs=y)\n",
+        "\n",
+        "  return y"
+      ],
+      "metadata": {
+        "id": "Qg3kI7QCJ_zG"
+      },
+      "execution_count": 6,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "key = jax.random.PRNGKey(200)\n",
+        "keys = jax.random.split(key, 20000)\n",
+        "\n",
+        "cond_model0 = condition(galton_board, {'theta': -0.8})\n",
+        "x0 = jax.vmap(lambda k: trace(seed(cond_model0, k)).get_trace()['y']['value'])(keys)\n",
+        "\n",
+        "cond_model1 = condition(galton_board, {'theta': -0.6})\n",
+        "x1 = jax.vmap(lambda k: trace(seed(cond_model1, k)).get_trace()['y']['value'])(keys)"
+      ],
+      "metadata": {
+        "id": "ilxOauMpKN8z"
+      },
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "p_estimated_0_numpyro, _ = np.histogram(x0, bins=31, range=(0, 31), density=True)\n",
+        "p_estimated_1_numpyro, _ = np.histogram(x1, bins=31, range=(0, 31), density=True)"
+      ],
+      "metadata": {
+        "id": "ec63wiKvKXm1"
+      },
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "figure(figsize=(10,6))\n",
+        "\n",
+        "plt.step(range(len(p_estimated_0)), p_estimated_0,\n",
+        "         c='r', lw=1.5,\n",
+        "         label=r'$p(x|\\theta_0)$ with mining gold simulator')\n",
+        "\n",
+        "plt.step(range(len(p_estimated_0)), p_estimated_1,\n",
+        "         c='b', lw=1.5, \n",
+        "         label=r'$p(x|\\theta_1)$ with mining gold simulator')\n",
+        "\n",
+        "plt.step(range(len(p_estimated_0_numpyro)), p_estimated_0_numpyro,\n",
+        "         c='C1', lw=1.5,\n",
+        "         label=r'$p(x|\\theta_0)$ with numpyro')\n",
+        "\n",
+        "plt.step(range(len(p_estimated_1_numpyro)), p_estimated_1_numpyro,\n",
+        "         c='skyblue', lw=1.5, \n",
+        "         label=r'$p(x|\\theta_1)$ with numpyro ')\n",
+        "\n",
+        "plt.xlabel(\"x\")\n",
+        "plt.ylabel(\"p(x)\")\n",
+        "plt.legend()\n",
+        "plt.title('check numpyro simulator')"
+      ],
+      "metadata": {
+        "id": "EzWaIdPKKZHL",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 421
+        },
+        "outputId": "5dd5c983-4161-4897-8608-c20f6c23e7a4"
+      },
+      "execution_count": 137,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "Text(0.5, 1.0, 'check numpyro simulator')"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 137
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 720x432 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmcAAAGDCAYAAABuj7cYAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzde3xU9Z3/8deXkBAgrMZgpKBCKBeBBIdELoIJoYjCDxVIrZTLKlJh3doi2rJaL4B2UVouWttSCxXUCsqCFVGptSxml4gXEhyWS6UBTCWChkvAJCYQwvf3x0zSXCGZM2NOkvfz8ZiHmZnv+ZzPmQHz5ntuxlqLiIiIiLhDq8ZuQERERET+SeFMRERExEUUzkRERERcROFMRERExEUUzkRERERcROFMRERExEUUzkSkgjFmmjEmIwR1c4wx1we7bnNkjCk0xnQPQd1UY0xusOuKSPApnImIuIi1Nspae7AxewhVSBeR+lE4ExFxyBjTurF7cBN9HiLOKJyJtEDGmCuMMX8yxhw1xhw3xvym2vuLjTH5xphPjTFjKr1+kTHmOWPMEWPM58aY/zTGhFV6f4Yx5m/GmAJjzF5jTGIt6+7jrzupjt6sMeZuY0y2MeakMea3xhjjf2++MealSmO7+ce39j9P9/e0zb978A1jTIwxZrUx5itjzHZjTLdq65pljDlojDlmjFlkjGlljIkwxpwwxiRUGhtrjPnaGHNp+S5CY8wDxpgvgFXGmDbGmKeNMYf9j6eNMW3q2MYexpj/Mcac8q93bbWeevh/ft4Ys8wY82f/9rxnjOnkr51vjPnEGDOgtmUrLf+fdfTwoDHmQKXvakL59wM8C1zrX+fJSt/9i/4/M/8wxjxijGnlf2+av7enjDHHgfm1rVNE6kfhTKSF8YepN4F/AN2ALsArlYYMBvYBHYFfAs+VhyPgeeAs0AMYANwA3OWv+z18v5RvB/4FuAU4Xm3dicBfgB9ba18+T5s3AQOB/sBtwI0N2MTvA//q365vA+8Dq4BLgL8B86qNnwBcAyQC44Dp1toz+D6TqZXGTQL+21p71P+8k79mV2Am8DAwBPAAVwODgEfq6PHnwDtANHA58OvzbM9t/jodgdP+7dnhf74eWHqeZc/nAJAMXAQ8BrxkjPmWtfZvwN3A+/5drBf7x//aP7Y7MBzf93xnpXqDgYPAZcCCAHsSERTORFqiQUBnYI61tshaW2KtrXx80T+stSustWXAC8C3gMuMMZcB/w+Y7V8uD3gKXxgCX0j7pbV2u/XZb639R6W6ycBG4HZr7ZsX6HGhtfaktfYz4F18gae+VllrD1hrTwF/Bg5Yazdba88C6/CFysp+Ya094V/X0/hCGP5tn1QpmP4r8MdKy50D5llrT1tri4EpwOPW2jx/gHvMv0xtSvGFus61fP7VvWatzbLWlgCvASXW2hf938/aWranXqy166y1h62156y1a4FsfH82avAH+u8DP7PWFlhrc4Al1bbvsLX219bas/7PQ0QCpHAm0vJcgS+Ana3j/S/Kf7DWfu3/MQpfmAgHjvh3N54Efg/EVqp74DzrvRvYZq1Nr0ePX1T6+Wv/+uvry0o/F9fyvHqtQ5V+/ge+4Iq19kP/ulONMVfhmy3cWGnsUX9gKtfZv3yNWrX4D8AAHxlj9hhjpgdxe+rFGHO7McZb6buMxzcbV5uO+L776tvXpdLzQ4hIUCicibQ8h4ArAzho+xC+3WodrbUX+x//Yq3tV+n9b59n+bv9632q4S1XKALaVXreyUGtcldU+vlK4HCl5y/g27X5r8D6amHMVqtzGF+AravWPxe09gtr7QxrbWfg34BllY8Vc+Br6vH5GGO6AiuAHwEx/l2Xu/EFRqi5bcf452xfuSuBzys9r76MiARI4Uyk5fkIOAIsNMa0N8ZEGmOGXWgha+0RfMdJLTHG/Iv/wPlvG2OG+4f8AfipMSbJ+PTwh4ByBcBoIMUYszDA3r3+5a80xlwE/CzAOpXNMcZEG2OuAO7Ft6uw3Ev4jkmbCrx4gTovA4/4TxjoCMz1L1+DMeZ7xpjL/U/z8QWbcw62oZwXmGyMCTPGjMZ3bFht2vvXedTfz534Zs7KfQlcboyJAPDvQv0vYIExpoP/e72fOrZPRJxROBNpYfy/aG/Gt5vuMyAXmFjPxW8HIoC9+ELFenzHpGGtXYfvQPA1+ILYBnwHzFde90lgFDDGGPPzAHr/K77w9H9AFr4TG5x63V/LC7wFPFdpfYfwHXxvga0XqPOfQKa/t13+5Wo9UxLfyQ4fGmMK8e0qvTdI1za7F993exLfMXAbahtkrd2L75ix9/EFsQTgvUpDtgB7gC+MMcf8r/0Y38zlQSAD3/e8Mgg9i0g1xlrNRItIy2SMsUBPa+3+84xZie9g97rOvBQRCSpdKFBEpA7+a6KlEeAZkSIigdBuTRGRWvh3u+4GFllrP23sfkSk5dBuTREREREX0cyZiIiIiIsonImIiIi4SLM5IaBjx462W7dujd2GiIiIyAVlZWUds9ZeWtt7zSacdevWjczMzMZuQ0REROSCjDH/qOs97dYUERERcRGFMxEREREXUTgTERERcRGFMxEREREXUTgTERERcRGFMxEREREXUTgTERERcRGFMxEREREXUTgTERERcRGFMxEREREXUTgTERERcZFmc29NEZFg8x4rYU9+ieM6/aIj8XSMDEJHItISaOZMRKQOe/JLyCsuc1Qjr7gsKAFPRFoOzZyJiJxHbNswpvS8OODlV2efDGI3ItISaOZMRERExEUUzkRERERcROFMRERExEUUzkRERERcROFMRERExEUUzkRERERcROFMRERExEV0nTMREZdbvhzWrHFeZ/JkmDnTeR0RCS3NnImIuNyaNeD1Oqvh9QYn4IlI6GnmTEQkhI4chrw8WDEj8BpeL3g8kJ4eeI3U1MCXFZFvlmbORERCKC8PCgud1fB4fLskRaRl0MyZiEiIRUU5m/UKiiOH4cs8SJ3trI4OXBMJOc2ciYi0BF8GYQpPB66JfCM0cyYi0lI4ncLTgWsi3wiFMxGROgTjYP6+d/gykYhIfWm3pohIHYJxMH9UFMTGBqcfEWkZNHMmInIeTvcErs6GvOIyVmefdNRHv+hIPB0jHdUQkaZB4UxEJIT6RUcCJY5q5BWXASUKZyIthMKZiDRL3mMl7Ml3Foo6dCmj4PMwRzU8HZ3PeDmddRORpkXhTESapT35JeQVlxHbNvBwVfB5GId3RML3gthYI7kpfiPXX/XfsMrB2QmebPgyOnhNiUitFM5EpNmKbRvGlJ4XB7y8k7M03eb6q/6bHpfuBzyBF4kqDlo/IlK3kIYzY8xo4FdAGPAHa+3Cau+3AV4EkoDjwERrbY4xJhz4A5Do7/FFa+2ToexVRKS523+0B54n3wq8wOwuwWtGROoUsktpGGPCgN8CY4C+wCRjTN9qw34A5FtrewBPAb/wv/49oI21NgFfcPs3Y0y3UPUqIiIi4hahnDkbBOy31h4EMMa8AowD9lYaMw6Y7/95PfAbY4wBLNDeGNMaaAucAb4KYa8i4jLLlzu7U9Cge/zXF+sZtJYaldPLcRSOf4zOf89wslNTRL4hobwIbRfgUKXnuf7Xah1jrT0LnAJi8AW1IuAI8Bmw2Fp7IoS9iojLrFnju5VjoAoLfReRbQ76RUc6OrEBoKBjHId7XRekjkQklNx6QsAgoAzoDEQDW40xm8tn4coZY2YCMwGuvPLKb7xJEQktjyfwC8D+xzpfQHNyO0iv19dDYwvG5Th+v89B0hWRb1Qow9nnwBWVnl/uf622Mbn+XZgX4TsxYDLwtrW2FMgzxrwHXANUCWfW2uXAcoBrrrnGhmIjRKRpCsYtkzwemDzZeZ1mxWniBd+HOnNmUNoRaY5CGc62Az2NMXH4Qtj38YWuyjYCdwDvA7cCW6y11hjzGfAd4I/GmPbAEODpEPYqIs3Mtzr7Hr9Mb+xOmpFgJN7yfdUKZyJ1Clk4s9aeNcb8CPgLvktprLTW7jHGPA5kWms3As/hC2D7gRP4Ahz4zvJcZYzZAxhglbX2/0LVq4iI1EN54n3aweU4nM66ibQAIT3mzFq7CdhU7bW5lX4uoZZrb1trC2t7XUSkRcpcBbvWOyrRtvOPKC5tG6SGRCSUQnm2poiIBMOu9fDFLkclikvbkv+1br0k0hS49WxNEWnhLr+2hM6JJazODmx5p/fVdJ1OCXBn4LsTD6z6nMKySEd7FZ/2+A476xx4CRGpB4UzEQk677ES9uSXOKoRf9tZ/0+B/W8qtm0Y/aKdXX6iOYkNz8d3ZaLAFRb6/qtwJhJaCmciEnR78kscz1yd2N+awzsiefBJBaxg+Fab43yrzXF+mR74/TG9s4PYkIjUSeFMREIitm0YU3peHPDyK2YEsRkJmh5Ru2DV2MALeLLhSx37JnI+CmciIlIvm7+8FcDZ/TmjioPSi0hzpnAmIiL18uaRO3nzyJ2kO7kk+OzAd6uKtBS6lIaIiIiIiyiciYiIiLiIwpmIiIiIiyiciYiIiLiIwpmIiIiIi+hsTRGpIhhX9292t05qbEcOQ14eju69dMcciIoKWksiEjqaORORKsqv7u+Ebp0UZHl5/7x3UqCionw3xhQR19PMmYjU4PTq/hICUVGQnh748tknySsuY3X2yYBLDLoHDu+IBBS8RUJJ4UxEpAXwzWQ6213doUsZnSlB4UwktBTORERaAE/HSDwdnYWq//AGPusmIvWncCYiQbd8OaxZ46yG1wseRzdxFBFpmnRCgIgE3Zo1vnDlhMcDkycHpx8RkaZEM2ciEhIej7Pj10VEWirNnImIiIi4iMKZiIiIiIsonImIiIi4iMKZiIiIiIsonImIiIi4iM7WFBEJpcxVsGu9sxpRxVDYNjj9iIjrKZyJiITSrvXwxS7olBB4jcK28GV08HpqbIWFkJrqrMbkyTBzZlDaEXEbhTMRkVDrlAB3vhX48k6DjJvExjqvUX6FY4UzaaYUzkRE5Jvzrc6+x9MKqyJ10QkBIiIiIi6imTMRqeLIYcjLgxUzAq+hm5aLiARO4UxEqsjL8x2v7YRuWl5Jedp1sitOaVekRVE4E5EaoqJ00/KgUdoVkQZSOBMRCTWlXRFpAJ0QICIiIuIimjkTEZF6c3r92Kc9vkuddQ5aRyLNj8KZiIjUSzCuH1t++J3CmUjdFM5ERKReyq8f+8v0wGt4ZwetHZFmS+FMRKQuumm5iDQCnRAgIlKX8puWO9HcblouIiGnmTMRkfPRTctF5BummTMRERERF1E4ExEREXERhTMRERERF1E4ExEREXERhTMRERERF9HZmiLNiPdYCXvySxzV6NCljILPw4LUkYiINJRmzkSakT35JeQVlzmqUfB5GId3RAapIxERaSjNnIk0I0cOQ15eGK//9uKAa1x9dhU/vWY9rHLYTMKtcM2dDouIiLQ8mjkTaUby8v55Y+lA3XnNevpEO7wq/he7nN/2SESkhdLMmUgzExUF6ekOCqwCcHhV/FVjHTQgItKyaeZMRERExEU0cybiFpmrHO8K/HbsA+QXXQSp4wMv4smG2FhHfTQbvoP4nN0f0+sFjydoLYlI86dwJuIWu9b7jtXqlBBwibati6DtOWd9OD1orTkJxkF8Hg9MnhycfkSkRVA4E3GTTs6O9Sp+Mx0Mzg46m90l8GWbI8cH8TUvecVlrM4+GfDyhTc+SOeDH6C5RJG6KZyJiEi99IuOBJxd5Ljgkis5HJx2RJothTMREakXT8dIPB2dXaD49392eJkWkRZA4UykmWkbXuzsUhZRxVDYNngNiYhIgyiciTQj+V9HQzuHRQrbwpfRQelHREQaLqThzBgzGvgVEAb8wVq7sNr7bYAXgSTgODDRWpvjf68/8HvgX4BzwEBrrbODHUTcLAiXbTgx9UVOFHV0dgFZJ5eNEBERx0IWzowxYcBvgVFALrDdGLPRWru30rAfAPnW2h7GmO8DvwAmGmNaAy8B/2qt3WmMiQFKQ9WriCsE47INYWEQEe68F6/XWUhzw7XSgnDdOO3iFZHGEMqZs0HAfmvtQQBjzCvAOKByOBsHzPf/vB74jTHGADcA/2et3QlgrT0ewj5F3MPpZRvWBX6JgwrBuCbXyZMQWeD8shxdb4T7Vga2bBCuG6ddvKHRNqzI2XGRnmx9L9KshTKcdQEOVXqeCwyua4y19qwx5hQQA/QCrDHmL8ClwCvW2l9WX4ExZiYwE+DKK68M+gaItEgzZ/oeTjw1Hf7xF2c12hY6r+HwunHaxRt8+WcuhQiHRaKKg9KLiFu59YSA1sB1wEDga+C/jTFZ1tr/rjzIWrscWA5wzTXX2G+8SxGpXaCzXZXpYrjN0okznThxppOz0Kw/G9LMhfLG558DV1R6frn/tVrH+I8zuwjfiQG5wP9aa49Za78GNgGJIexVRERExBVCGc62Az2NMXHGmAjg+8DGamM2Anf4f74V2GKttcBfgARjTDt/aBtO1WPVRERERJqlkO3W9B9D9iN8QSsMWGmt3WOMeRzItNZuBJ4D/miM2Q+cwBfgsNbmG2OW4gt4FthkrXUwBy4iIiLSNIT0mDNr7SZ8uyQrvza30s8lwPfqWPYlfJfTEGkRvD2/y57uY8DBTaU7dCmj4POwIHbVyAoLAz8o3w2X8xARCYBbTwgQaXH2dB9D3iW9cRInCj4P4/COyDr+ydPExMb6zsqLyg5s+cgC+PtJZ2dcer3g8QS+vIhIABTORFwk9sQ+pgweE/DyK2YEsZnGdsMsZxeRPXIY/uHw2tUeT3Cu+yYi0gAKZyLiTtfc6XuIiLQwoTxbU0REREQaSOFMRERExEUUzkRERERcROFMRERExEUUzkRERERcROFMRERExEUUzkRERERcROFMRERExEUUzkRERERcROFMRERExEUUzkRERERcROFMRERExEUUzkRERERcROFMRERExEVaN3YDIs1C5irYtd5RCdv5HopK25GaGngNrxc8HkdtiIhII9PMmUgw7FoPX+xyVKKotB1fFF7mqIbHA5MnOyohIiKNTDNnIsHSKQHufCvgxQ+s+hyA9PQg9SMiIk2SZs5EREREXEThTERERMRFFM5EREREXEThTERERMRFdEKAiIh8owoLcXTJmKd79CA2PJ/OQetIxF0UzkSC4chhyMtz9htn6osQFha0lkTcKDbWeY3CsrYACmfSbCmciQRDXp5vOsCJsDCICA9OPyIu9a3Ovscv0wOv4b2rOGj9iLiRwplIsERFObtI2bqTQWtFRESaLoUzERFpesrKnB1GAL7bacycGZR2RIJJZ2uKiEjTEh7u/PhMrxfWrAlOPyJBppkzERFpWtq08T3SA79dmuNZN5EQ0syZiIiIiIsonImIiIi4iMKZiIiIiIsonImIiIi4iMKZiIiIiIsonImIiIi4iMKZiIiIiIsonImIiIi4iMKZiIiIiIsonImIiIi4SIPCmTGmvTHG4Q3NRERERKQu5w1nxphWxpjJxpi3jDF5wCfAEWPMXmPMImNMj2+mTREREZGW4UIzZ+8C3wZ+BnSy1l5hrY0FrgM+AH5hjJka4h5FREREWozWF3j/emttafUXrbUngFeBV40x4SHpTERERKQFOu/MWXkwM8ZcX/09Y8wdlceIiIiIiHP1PSFgrjHmd/4TAi4zxrwB3BzKxkRERERaovqGs+HAAcALZABrrLW3hqwrERERkRaqvuEsGhiEL6CdBroaY0zIuhIRERFpoeobzj4A3rbWjgYGAp2B90LWlYiIiEgLdaGzNctdb639DMBaWwzMMsakhK4tERFprvKKy1idfTLg5QtvfJDOBz/AE8SeRNzkvOHMGNPNWptTHswqs9b+r3/XZhdrbW7IOhQRkWajX3QkUOKoRsElV3I4OO2IuNKFZs4WGWNaAa8DWcBRIBLoAYwARgLzAIUzERG5IE/HSDwdIx3V+P2fdwWpGxF3Om84s9Z+zxjTF5gCTAc6AcXA34BNwAJrrbN/AomIiIhIhQsec2at3WuM+U/gh/hu22SB7cB6BTMRH2/P77Kn+xhwcBxNhy5lFHweFsSuRESkKarv2ZovAH2AZ4BfA32BF0PVlEhTs6f7GPIu6e2oRsHnYRze4Wx3j4iINH31PVsz3lrbt9Lzd40xe0PRkEhTFXtiH1MGjwl4+RUzgtiMiIg0WfWdOdthjBlS/sQYMxjIDE1LIiIiIi1XfWfOkoBtxpjyS2pcCewzxuwCrLW2f20LGWNGA78CwoA/WGsXVnu/Db7do0nAcWCitTan0vtXAnuB+dbaxfXeKpGGyFwFu9Y7q9Hlh1BW33/riIiI1K2+4Wx0QwsbY8KA3wKj8F1qY7sxZqO1tvLu0B8A+dbaHsaY7wO/ACZWen8p8OeGrlukQXathy92QaeEwGuUtYIz4cHrSUREWqx6hTNr7T8CqD0I2G+tPQhgjHkFGIdvJqzcOGC+/+f1wG+MMcZaa40x44FPgaIA1i3SMJ0S4M63Al9+3f8ErxcREWnRQrkfpgtwqNLzXP9rtY6x1p4FTgExxpgo4AHgsRD2JyIiIuI6bj1IZj7wlLW28HyDjDEzjTGZxpjMo0ePfjOdiYiIiIRQfY85C8TnwBWVnl/uf622MbnGmNbARfhODBgM3GqM+SVwMXDOGFNirf1N5YWttcuB5QDXXHONDclWiIiIiHyDQhnOtgM9jTFx+ELY94HJ1cZsBO4A3gduBbZYay2QXD7AGDMfKKwezETc5MjpGPJKo1mRGngNrxc8nqC1JNKstQ0rglVjAy/gyYYvo4PXkEgQhSycWWvPGmN+BPwF36U0Vlpr9xhjHgcyrbUbgeeAPxpj9gMn8AU4kSYnrzSawjJnV/f3eGBy9X++iEgN+WcuhQiHRaKKg9KLSCiEcuYMa+0mfDdIr/za3Eo/lwDfu0CN+SFpTiTIosJKSE9v7C5Emr8TZzpx4kwnZ2dYz65+fpqIe7j1hAARERGRFknhTERERMRFFM5EREREXEThTERERMRFFM5EREREXEThTERERMRFFM5EREREXEThTERERMRFFM5EREREXEThTERERMRFQnr7JpEm4chhyMuD1NTAa0x9EcLCgtaSiIi0XJo5E8nLg8JCZzXCwiAiPDj9iIhIi6aZMxGAqCgc3bV83cmgtSIiIi2bZs5EREREXEThTERERMRFFM5EREREXEThTERERMRFFM5EREREXEThTERERMRFFM5EREREXETXORMRkSansNDZTT2e7tGD2PB8OgetI5HgUTgTEZEmJTbWeY3CsrYACmfiSgpnIiLSpHyrs+/xy/TAa3jvKg5aPyLBpmPORERERFxEM2fS4nl7fpc93cdAduD3x+zQpYyCz8OC2JWIiLRUmjmTFm9P9zHkXdLbUY2Cz8M4vCMySB2JiEhLppkzESD2xD6mDB4T8PIrZgSxGRERadE0cyYiIiLiIgpnIiIiIi6icCYiIiLiIgpnIiIiIi6icCYiIiLiIgpnIiIiIi6icCYiIiLiIgpnIiIiIi6icCYiIiLiIrpDgDRtmatg13pnNbr8EMr07xQREXEH/UaSpm3Xevhil7MaZa3gTHhw+hEREXFIM2fS9HVKgDvfCnz5df8TvF5EREQc0syZiIiIiIsonImIiIi4iMKZiIiIiIvomDMREWmZysogNdVZjcmTYebMoLQjUk4zZyIi0vKEh0NYmLMaXi+sWROcfkQq0cyZiIi0PG3a+B7pDs70djrrJlIHzZyJiIiIuIhmzqTFO3I6hrzSaFakBl7D6wWPJ2gticgF5BWXsTr7ZMDLF974IJ0PfoD+2oobKZxJi5dXGk1hWaSjGh6P77hgEQm9ftGRQImjGgWXXMnh4LQjEnQKZyJAVFgJ6emN3YWI1IenYySejs7+QfX7Pzu87ZtICOmYMxEREREXUTgTERERcRGFMxEREREXUTgTERERcRGFMxEREREXUTgTERERcRGFMxEREREXUTgTERERcRGFMxEREREXUTgTERERcZGQhjNjzGhjzD5jzH5jzIO1vN/GGLPW//6Hxphu/tdHGWOyjDG7/P/9Tij7FBEREXGLkIUzY0wY8FtgDNAXmGSM6Vtt2A+AfGttD+Ap4Bf+148BN1trE4A7gD+Gqk8RERERNwnljc8HAfuttQcBjDGvAOOAvZXGjAPm+39eD/zGGGOstR9XGrMHaGuMaWOtPR3CfkUaRWlpKbm5uZSUlDR2KyJNTmRkJJdffjnh4eGN3YpI0IQynHUBDlV6ngsMrmuMtfasMeYUEINv5qzcd4EdtQUzY8xMYCbAlVdeGbzORb5Bubm5dOjQgW7dumGMaex2RJoMay3Hjx8nNzeXuLi4xm5HJGhCGc4cM8b0w7er84ba3rfWLgeWA1xzzTX2G2xN3OLIYcjLg9TUwGtMfRHCwoLWUkOVlJQomIkEwBhDTEwMR48ebexWRIIqlCcEfA5cUen55f7Xah1jjGkNXAQc9z+/HHgNuN1aeyCEfUpTlpcHhYXOaoSFQUTj7hJRMBMJjP7uSHMUypmz7UBPY0wcvhD2fWBytTEb8R3w/z5wK7DFWmuNMRcDbwEPWmvfC2GP0hxERUF6euDLrzsZtFZEREScCtnMmbX2LPAj4C/A34D/stbuMcY8boy5xT/sOSDGGLMfuB8ov9zGj4AewFxjjNf/iA1VryIiIiJuEdLrnFlrN1lre1lrv22tXeB/ba61dqP/5xJr7festT2stYPKz+y01v6ntba9tdZT6ZEXyl5FpHbFxcUMHz6csrKy845LTU0lJycHgLKyMu6991769etHQkICBw8erHWZM2fOkJKSwtmzZwPqbejQoQCcPHmSZcuWVbyek5NDfHx8QDXPtx6nY0IlKiqq1tfnz5/P4sWL610nmNtQV0/lqn9nIvJPukOAiJzXypUrSUtLI6wBJ008+eSTdO/enT179jBr1qw6fwlHREQwcuRI1q5dG1Bv27ZtA0L/i758PU7HuN03uQ2BfGfWWs6dOxeijkTcw9Vna4pciLfnd9nTfQxkB37cWIcuZRR83nhna7rFpEmTOHfuHJ9++ilffvklywwbHskAACAASURBVJYtY+zYsaxevZo1a9ZUjBsxYgQPPfQQo0aN4pFHHuHUqVP8+te/rni/qKiI1157jaysLADi4uJ466236lzv+PHj+dnPfsaUKVOqvL5o0SLatGnDrFmzuO+++9i5cydbtmxhy5YtPPfcc6xevZqoqCgKCwt58MEHOXDgAB6Ph1GjRnHPPfdQVlbGjBkz2LZtG126dOH111+nbdu2FfVzcnIYPXo0Q4YMYdu2bQwcOJA777yTefPmkZeXx+rVqxk0aBBAxXpycnIYM2YM1113XY269Rnz85//nJdeeolLL72UK664gqSkJH7605/W+EzqGrd06VJWrlwJwF133cXs2bNrLLtgwQJeeOEFYmNjK5atrqioiNtuu43c3FzKysp49NFHmThxYpVtuNBnExsby0033cTu3bsBWLx4MYWFhcyfP7/W7/jQoUOUlJRw7733MnPmzBrf2aJFi2rdvpycHG688UYGDx5MVlYWmzZtomvXrnX+eWqItmFFsGps4AU82fBldFB6EalM4UyatD3dx5B3SW+cHJBY8HkYh3dEwveC1lbgZs8Grze4NT0eePrpCw7buXMn48aNY+3atWRkZHD//fczatQoDh48SLdu3SrGPfbYY8ydO5e8vDw+/vhjNm7cWKXO5s2bOXToEB6PB4ATJ05w/fXX17ne+Ph4tm/fXuP15ORklixZwqxZs8jMzOT06dOUlpaydetWUlJSqoxduHAhu3fvxuv/7HJycsjOzubll19mxYoV3Hbbbbz66qtMnTq1ynL79+9n3bp1rFy5koEDB7JmzRoyMjLYuHEjTzzxBBs2bKjRV33q1jamd+/evPrqq+zcuZPS0lISExNrDU7bt2+vdVxWVharVq3iww8/xFrL4MGDGT58OAMGDKhYNisri1deeQWv18vZs2frXMfbb79N586dK0LzqVOnaoy50GfzdD3+TJVbuXIll1xyCcXFxQwcOJDvfve7Nb6zurYvOjqa7OxsXnjhBYYMGVLvdV5I/plLIcJhkajioPQiUp3CmTR5sSf2MWXwmICXXzEjiM00USUlJRw9epR58+YB0LdvX/Lz8zl27BgXX3xxlbEpKSlYa1m6dCnp6ek1dnd6vV4ef/xx7r77bsA3A9K/f3+Kior44Q9/SEREBKmpqRUzZWFhYURERFBQUECHDh0q6pQHkq+++oo2bdqQmJhIZmYmW7du5ZlnnrngNsXFxVUExKSkpIrj4aqPSUhIAKBfv36MHDkSYwwJCQm1jm9I3epjjh07xrhx44iMjCQyMpKbb7651vrvvfdereMyMjKYMGEC7du3ByAtLY2tW7dWCWdbt25lwoQJtGvXDoBbbrml5gqAhIQEfvKTn/DAAw9w0003kZycHJTPpi7PPPMMr732GgCHDh0iOzubTp06VRlT1/bdcsstdO3aNajBDODEmU6cONMJ7qx7VveCZncJXkMilSicibhJA2Yjgmn37t307NmTyMhIAHbs2MHVV19N27Zta9xWateuXRw5coSYmJgqYapcfn5+xdXaz549yzvvvMPDDz/Mn/70J2699VZuvvlmJk6cWGU35unTpyvWXS48PJy4uDief/55hg4dSv/+/Xn33XfZv38/ffr0ueA2tWnTpuLnsLAwiotrznJUHtOqVauK561atarzJIWG1q1rTGPq1asXO3bsYNOmTTzyyCOMHDmSuXPnVhlzoc+mdevWVY7/quv2Y+np6WzevJn333+fdu3akZqa2uBblZUHNpGWQicEiAg7d+7ks88+o6SkhKKiIubNm8d9991HdHQ0ZWVlFb9Mjxw5wpQpU3j99deJiori7bffrlGrV69efPDBBwA89dRTjB07lri4OHJzc7niCt91qSvPth0/fpyOHTvWem/E5ORkFi9eTEpKCsnJyTz77LMMGDCgxoVHO3ToQEFBQdA+j1AYNmwYb7zxBiUlJRQWFvLmm282aFxycjIbNmzg66+/rjiur/qMV0pKChs2bKC4uJiCggLeeOONWtdx+PBh2rVrx9SpU5kzZw47duxo8PZcdtll5OXlcfz4cU6fPl3n9pw6dYro6GjatWvHJ598UvFno/p3Vp/tE2kpNHMmIuzcuZO0tDQGDx5MaWkpDz30EMOGDQPghhtuICMjg6FDh5KWlsaSJUvo06cPjz76KA888ACjR4+uUmvSpEmMGTOGHj16cO2117J8+XIALr/8cnJzc/F4PFVmXN59913Gjq39oOzk5GQWLFjAtddeS/v27YmMjKz1F3ZMTAzDhg0jPj6eMWPGcM899wTrowmagQMHcsstt9C/f38uu+wyEhISuOiii+o9LjExkWnTplWcpHDXXXdV2aUJkJiYyMSJE7n66quJjY1l4MCBtfaya9cu5syZQ6tWrQgPD+d3v/tdg7cnPDycuXPnMmjQILp06cJVV11V67jRo0fz7LPP0qdPH3r37l2xe7L6d7Zo0aJat6+hu1BFmgVrbbN4JCUlWWl5Xtq0yb60aZOjGsOH+x6NZe/evY23cr+UlBT7ySef1PpeVlaWnTp16gVrDB8+3H766ad1vl9YWGinTZtm7777bvvSSy9VvD5hwgS7b9++BvfcFBUUFFhrrS0qKrJJSUk2KyvL0TjxCeTv0Jz/yrdz/ivf2Yrv7ex7iAQAyLR1ZBrNnIkIBw4coGfPnrW+l5iYyIgRIygrK2vQtc6qa9++PatWrary2pkzZxg/fjy9evUKuG5TMnPmTPbu3UtJSQl33HEHiYmJjsaJSPOkcCYi5Obmnvf96dOnX7DGtGnTapzZeSERERHcfvvtDVqmKat8vbhgjBNnCgshNTXw5Z/u0YPY8Hw6B60jER+FMxEJimnTpjV2CyL1FhuEuzUXlvkuaqxwJsGmcCYiIi3Otzr7Hr9MD7yG9y53XSJFmg9dSkNERETERRTORERERFxE4UxERETERRTORERERFxE4UxERETERRTORERERFxE4UxEzqu4uJjhw4dTVlZ23nGpqakV90EsKyvj3nvvpV+/fiQkJHDw4MFalzlz5gwpKSmcPXs2oN6GDh0KwMmTJ1m2bFnF6zk5OcTHxwdU83zrcTomVKKiomp9ff78+SxevLjedYK5DXX1VK76dyYi/6RwJiLntXLlStLS0hp066Ynn3yS7t27s2fPHmbNmlXnL+GIiAhGjhzJ2rVrA+pt27ZtQOh/0Zevx+kYt/smtyGQ78xay7lz50LUkYh7KJxJ48lcBavGOnuE6X/UwTJp0iQmTpzIoEGD6Nq1K2+99RYAq1evZty4cRXjRowYwV//+lcAHnnkEX784x9XqVNUVMRrr73GvffeC0BcXBz79++vc73jx49n9erVNV5ftGgRzzzzDAD33Xcf3/nOdwDYsmULU6ZMAf45O/Pggw9y4MABPB4Pc+bMAXyzdzNmzKBfv37ccMMNFBdXvWBoTk4OV111FdOmTaNXr15MmTKFzZs3M2zYMHr27MlHH31UMbZ8PTk5OfTp06fWuvUZ8/Of/5zevXtz3XXXMWnSpDpnteoat3TpUuLj44mPj+fpp5+uddkFCxbQq1cvrrvuOvbt21frmKKiIsaOHcvVV19NfHx8RTiuvA0X+myqz04uXryY+fPn17q+8ePHk5SURL9+/Vi+fDlQ+3dW2/bl5OTQu3dvbr/9duLj4zl06FCt6xBpTnSHAGk8u9bDF7ugU0LgNcpawZnw4PXUyGbPBq83uDU9Hqjj93gVO3fuZNy4caxdu5aMjAzuv/9+Ro0axcGDB+nWrVvFuMcee4y5c+eSl5fHxx9/zMaNG6vU2bx5M4cOHcLj8QBw4sQJrr/++jrXGx8fz/bt22u8npyczJIlS5g1axaZmZmcPn2a0tJStm7dSkpKSpWxCxcuZPfu3Xj9H15OTg7Z2dm8/PLLrFixgttuu41XX32VqVOnVllu//79rFu3jpUrVzJw4EDWrFlDRkYGGzdu5IknnmDDhg01+qpP3drG9O7dm1dffZWdO3dSWlpKYmIiSUlJNepv37691nFZWVmsWrWKDz/8EGstgwcPZvjw4QwYMKBi2aysLF555RW8Xi9nz56tcx1vv/02nTt3rgjgp06dqjHmQp9NXeGwNitXruSSSy6huLiYgQMH8t3vfrfGd1bX9kVHR5Odnc0LL7zAkCFD6r1OkaZM4UwaV6cEuPOtwJdf9z/B66UFKykp4ejRo8ybNw+Avn37kp+fz7Fjx2rczDwlJQVrLUuXLiU9Pb3G7k6v18vjjz/O3XffDcBdd91F//79OXjwIAsWLODUqVOsX7++YnxYWBgREREUFBTQoUOHitfLA8lXX31FmzZtSExMJDMzk61bt1bMqJ1PXFxcRUBMSkqqOB6u+piEBN8/Dvr168fIkSMxxpCQkFDr+IbUrT7m2LFjjBs3jsjISCIjI7n55ptrrf/ee+/VOi4jI4MJEybQvn17ANLS0ti6dWuVcLZ161YmTJhAu3btALjllltqXUdCQgI/+clPeOCBB7jppptITk4OymdTl2eeeYbXXnsNgEOHDpGdnU2nTp2qjKlr+2655Ra6du2qYCYtisKZiIs0YDIiqHbv3k3Pnj2JjIwEYMeOHVx99dW0bduWkpKSKmN37drFkSNHiImJqRKmyuXn5xMXFwfA2bNneeedd3j44YeJi4vjueee49Zbb62xzOnTpyvWXS48PJy4uDief/55hg4dSv/+/Xn33XfZv38/ffr0ueA2tWnTpuLnsLCwGrs1q49p1apVxfNWrVrVeZJCQ+vWNaYx9erVix07drBp0yYeeeQRRo4cydy5c6uMudBn07p16yrHf1X/c1IuPT2dzZs38/7779OuXTtSU1PrHFuX8sAm0lLomDNp0o6cjmFnYQ9SUwn4EezdiE3Rzp07+eyzzygpKaGoqIh58+Zx3333ER0dTVlZWcUv0yNHjjBlyhRef/11oqKiePvtt2vU6tWrFx988AEATz31FGPHjq0Ia7U5fvw4HTt2JDy85u7p5ORkFi9eTEpKCsnJyTz77LMMGDAAY0yVcR06dKCgoMDJRxByw4YN44033qCkpITCwkLefPPNBo1LTk5mw4YNfP311xXH9VWf8UpJSWHDhg0UFxdTUFDAG2+8Ues6Dh8+TLt27Zg6dSpz5sxhx44dDd6eyy67jLy8PI4fP87p06fr3J5Tp04RHR1Nu3bt+OSTTyr+bFT/zuqzfSIthWbOpEnLK42msCzywgPPw+OByZOD1FATtXPnTtLS0hg8eDClpaU89NBDDBs2DIAbbriBjIwMhg4dSlpaGkuWLKFPnz48+uijPPDAA4wePbpKrUmTJjFmzBh69OjBtddeW3EAeF3effddxo4dW+t7ycnJLFiwgGuvvZb27dsTGRlZ6y/smJgYhg0bRnx8PGPGjOGee+4J8JMInYEDB3LLLbfQv39/LrvsMhISErjooovqPS4xMZFp06YxaNAgwLe7uPIuTYDExEQmTpzI1VdfTWxsLAMHDqy1l127djFnzhxatWpFeHg4v/vd7xq8PeHh4cydO5dBgwbRpUsXrrrqqlrHjR49mmeffZY+ffrQu3fvit2T1b+zRYsW1bp9Dd2FKtIsWGubxSMpKclKE7Py//keDsxZmWvnrMwNUkONY+/evY3dgk1JSbGffPJJre9lZWXZqVOnXrDG8OHD7aefflrn+8eOHbP/9m//Zrt3726feOKJitcnTJhg9+3b1+Cem6KCggJrrbVFRUU2KSnJZmVlORonPoH8HXrp7/n2pb/nO1rvxz9IsR//IMVRDWm5gExbR6bRzJmIcODAAXr27Fnre4mJiYwYMYKysrIGXeusupiYGJ599tkqr505c4bx48fTq1evgOs2JTNnzmTv3r2UlJRwxx13kJiY6GicOJNXXMbq7JMBL184/jE6/z0DTxB7EgHt1hQRIDc397zvT58+/YI1pk2bVuPMzguJiIjg9ttvb9AyTdmaNWuCOk4C1y86EmjYiQnVFXSM47DFd/CqE5Mnw8yZzmpIs6JwJiJBMW3atMZuQaTePB0j8XR0drzq7//+f2AuPO68ys9IUjiTShTOREREAtHKAGGQnh54DaezbtIs6VIaIiIiIi6icCYiIiLiIgpnIiIiIi6icCYiIiLiIgpnIiIiIi6icCYiIiLiIgpnInJexcXFDB8+nLKysvOOS01NrbgPYllZGffeey/9+vUjISGBgwcP1rrMmTNnSElJ4ezZswH1NnToUABOnjzJsmXLKl7PyckhPj4+oJoiIo1N4UxEzmvlypWkpaU16NZNTz75JN27d2fPnj3MmjWrSnCqLCIigpEjR7J27dqAetu2bRtQM5w1ZdZazp0719htiEgjUjgTEQAmTZrExIkTGTRoEF27duWtt94CYPXq1YwbN65i3IgRI/jrX/8KwCOPPMKPf/zjKnWKiop47bXXuPfeewGIi4tj//79da53/PjxrF69usbrixYt4plnngHgvvvu4zvf+Q4AW7ZsYcqUKQBERUUB8OCDD3LgwAE8Hg9z5swBfLN3M2bMoF+/ftxwww0UFxdXqZ+Tk0OfPn1qHVN95m3x4sXMnz+fnJwcrrrqKqZNm0avXr2YMmUKmzdvZtiwYfTs2ZOPPvqoYvmrrrqKKVOm0KdPH2699Va+/vpr5s6dy9NPP11R9+GHH+ZXv/oVOTk59O7dm9tvv534+HgOHTrE0qVLiY+PJz4+vsoyItL86Q4B0mi8rT3s6XgdrPufgGt0+PZVFBwIbJeYK/35QfhiV3BrdkqAMQsvOGznzp2MGzeOtWvXkpGRwf3338+oUaM4ePAg3bp1qxj32GOPMXfuXPLy8vj444/ZuHFjlTqbN2/m0KFDeDy+20GfOHGC66+/vs71xsfHs3379hqvJycns2TJEmbNmkVmZianT5+mtLSUrVu3kpKSUmXswoUL2b17N17/rXBycnLIzs7m5ZdfZsWKFdx22228+uqrTJ06tcpy9RlT3f79+1m3bh0rV65k4MCBrFmzhoyMDDZu3MgTTzzBhg0bANi3bx/PPfccw4YNY/r06Sxbtozp06eTlpbG7NmzOXfuHK+88gofffQRBQUFZGdn88ILLzBkyBCysrJYtWoVH374IdZaBg8ezPDhwxkwYMB5exOR5kEzZ9Jo9nS8jrzo3o5qFBw4y+Ht9d/dJrUrKSnh6NGjzJs3D4C+ffuSn5/PsWPHatzMPCUlBWstS5cu5ZVXXqmxu9Pr9fL444/j9Xrxer3ccMMNeDweioqKuOOOO5gxY0aVmbKwsDAiIiIoKCioUicpKYmsrCy++uor2rRpw7XXXktmZiZbt24lOTn5gtsUFxdXERCTkpIqjodr6JjalklISKBVq1b069ePkSNHYowhISGhyvJXXHEFw4YNA2Dq1KlkZGTQrVs3YmJi+Pjjj3nnnXcYMGAAMTExAHTt2pUhQ4YAkJGRwYQJE2jfvj1RUVGkpaWxdevWC/YmIs2DZs6kUcXm72PK98YEvPyK1OD14gr1mOEKhd27d9OzZ08iI303gt6xYwdXX301bdu2paSkpMrYXbt2ceTIEWJiYujQoUONWvn5+cTFxQFw9uxZ3nnnHR5++GH+9Kc/ceutt3LzzTczceLEil2TAKdPn65Yd7nw8HDi4uJ4/vnnGTp0KP379+fdd99l//799OnT54Lb1KZNm4qfw8LCauzWPN+Y1q1bVznuq/JnUHmZVq1aVTxv1apVlRMbjKl6R+zy53fddRfPP/88X3zxBdOnT694v3379hfcJnGfsjKHt8f0Ps3k2M3otudSmWbORISdO3fy2WefUVJSQlFREfPmzeO+++4jOjqasrKyinBy5MgRpkyZwuuvv05UVBRvv/12jVq9evXigw8+AOCpp55i7NixxMXFkZubyxVXXAFQZbbt+PHjdOzYkfDw8Bq1kpOTWbx4MSkpKSQnJ/Pss88yYMCAGsGnQ4cONWbenLjsssvIy8vj+PHjnD59mjfffLPBNT777DPef/99ANasWcN1110HwIQJE3j77bfZvn07N954Y63LJicns2HDBr7++uuKY/jqM1so36yIcGjAeTK18hb2YE1e3bv9pWXSzJmIsHPnTtLS0hg8eDClpaU89NBDFbvkbrjhBjIyMhg6dChpaWksWbKEPn368Oijj/LAAw8wevToKrUmTZrEmDFj6NGjB9deey3Lly8H4PLLLyc3NxePx1NlVurdd99l7NixtfaVnJzMggULuPbaa2nfvj2RkZG1hpSYmBiGDRtGfHw8Y8aM4Z577nH0eYSHhzN37lwGDRpEly5duOqqqxpco3fv3vz2t79l+vTp9O3bl3//938HfGeojhgxgosvvrjOM2ATExOZNm0agwYNAnyzbTrezH0i2vge6emB10i9uO6TZaTlMtbaxu4hKK655hqbmZnZ2G1IA6z+858BmDIm8N2a5bsTnPzPsbH97W9/q9duulAaPnw4y5cvp3fvmscA7tixg6eeeoo//vGP562RmprK888/X+XkgcqKior40Y9+RGRkJNddd13Fbs20tDQWLlxIr169HG+HW+Tk5HDTTTexe/fuGu+dO3eOxMRE1q1bR8+ePRuhu+ansf4Ord66Fc4UMeWzXwdcw/teIZs/GclPM+YGsTNpCowxWdbaa2p7TzNnIsKBAwfqDAqJiYmMGDGCsrKyBl3rrLr27duzatWqKq+dOXOG8ePHN6tgdj579+7lpptuYsKECQpmzUH7Sx2X6HFp+cyZwpn8k8KZiJCbm3ve9ysfuF6XadOm1Tiz80IiIiK4/fbbG7RMU9CtW7daZ8369u1b590SpAnq0Mn3SH4r4BL77xoexIakuVA4E5GgmDZtWmO3ICLSLOhsTREREREXUTgTERERcRGFMxEREREX0TFnEpjMVbBrvaMStvM9FJW2c3R1ba8X/HffERERaRYUziQwu9b7btDdKSHgEkWl7fii8DJHbXg8MHmyoxIiIgHLKy5jdfbJgJcvHP8YnT/5XzxO/pU6eTLM1A2gmhOFMwlcpwS4M/BTyA+s+hxo2heQFZGWq190JFBywXHnU9AxjsNXAW9uCayA1+v7r8JZs6JwJiIiEgBPx0g8HSMd1fj9/l2+G3QG+q9UR3ddF7dSOJOAeGNS2RM9BBxM53foEU7B/tIgdiWhUFxczOjRo9myZct57xBQ+fZNZWVl3H///WzevJlWrVrx+uuv07179xrLnDlzhuuvv54tW7bQunXD/3c0dOhQtm3bxsmTJ1mzZg0//OEPgfPfPklExO0UziQge9olkhfRhVjvzoBrFJyK43D6abgziI1J0K1cuZK0tLQG3brpySefpHv37uzZs4cVK1awbNkyFi9eXGNcREQEI0eOZO3atRX32myIbdu2AXDy5EmWLVtWEc6aMmst1lpatdLJ9C1FWZmDCTDv00yO3Yx2ajYvCmcSmNIzxB7dy5Tf1vyFW18rvE/DZbFBbEqcmDRpEufOnePTTz/lyy+/ZNmyZYwdO5bVq1ezZs2ainEjRozgoYceYtSoUTzyyCOcOnWKX//6nzd+Lioq4rXXXiMrKwuAuLg43nqr7mMTx48fz89+9rMa4WzRokW0adOGWbNmcd9997Fz5062bNnCli1beO6551i9ejVRUVEUFhby4IMPcuDAATweD6NGjeKee+6hrKyMGTNmsG3bNrp06cLrr79O27ZtK+rn5OQwZswYrrvuuhpjqs+8LV68mMLCQqZNm8bo0aMZMmQI27ZtY+DAgdx5553MmzePvLw8Vq9ezaBBg8jJyWH06NEkJSWxY8cO+vXrx4svvsjChQu55JJLmD17NgAPP/wwsbGxjBs3jhtvvJHBgweTlZXFpk2bePXVV1m5ciUAd911V8Uy0rxEhMMZB8t7C3sAKJw1MyENZ8aY0cCvgDDgD9bahdXebwO8CCQBx4GJ1toc/3s/A34AlAGzrLV/CWWvLUqwLoNRFkUq6QHX8AKebzlqo9nZnFvIl8Vng1rzsratuf7yqAuO27lzJ+PGjWPt2rVkZGRw//33M2rUKA4ePEi3bt0qxj322GPMnTuXvLw8Pv74YzZu3Fh1GzZv5tChQ3j81zg5ceIE119/fZ3rjY+PZ/v27TVeT05OZsmSJcyaNYvMzExOnz5NaWkpW7duJSUlpcrYhQsXsnv3brz+g6NzcnLIzs7m5ZdfZsWKFdx22228+uqrTJ06tcpy9RlT3f79+1m3bh0rV65k4MCBrFmzhoyMDDZu3MgTTzzBhg0bANi3bx/PPfccw4YNY/r06Sxbtozp06eTlpbG7NmzOXfuHK+88gofffQRBQUFZGdn88ILLzBkyBCysrJYtWoVH374IdZaBg8ezPDhwxkwYMB5e5OmJ6INRJgi0u8YG9Dy3h6FbP5kJKBrCjUnIQtnxpgw4LfAKCAX2G6M2Wit3Vtp2A+AfGttD2PM94FfABONMX2B7wP9gM7AZmNML2ttWaj6bUm8h4+x58ofQ0T7gGt8EX4lRTlfO+pDl8Fwj5KSEo4ePcq8efMA3w268/PzOXbsWI2bmaekpGCtZenSpaSnp9fY3en1enn88ce5++67Ad+sT//+/Tl48CALFizg1KlTrF//z38chIWFERERQUFBAR06dKh4PSkpiaysLL766ivatGlDYmIimZmZbN26lWeeeeaC2xQXF1cREJOSksjJyQloTG3LJCT4LiHTr18/Ro4ciTGGhISEKstfccUVDBs2DICpU6fyzDPP8NOf/pSYmBg+/vhjvvzySwYMGEBMTAwFBQV07dqVIUOGAJCRkcGECRNo3973dzQtLY2tW7cqnDVH7S/9/+3df2xV9RnH8fdDKVwCZGBxxFEZZZTfggMsKVKUJSMwSKCMmTEJNsxIDAYX/hiIEZwZbiGgyzKjYYHgiMiIyiDEKCZ2c2SgCKMDqjB+KBYL9nEDBAAACjdJREFUhYIKiQVanv1xD11pe0t7ue05t3xeScO559d9+uR7ex/O9/s9h4oufXltwJKkDq/53iUGHdqb4qAkbK155SwPOOruxwHMbBMwHahbnE0Hng2W3wD+ZGYWrN/k7peBE2Z2NDjfrlaM96bWr32Ty72zwgwhJS7cHR/kdX7/5aTPcak6xjf/uKLbYKRYc65wtYaDBw+Sm5tLLBafebZv3z5GjhxJly5dqKq68VYBBw4coLy8nKysrBuKqesuXLhATk4OANXV1ezYsYOnn36anJwc1q5dy6xZsxocc/ny5dr3vi4zM5OcnBzWr1/PuHHjGDFiBMXFxRw9epQhQ4bc9Hfq3Llz7XJGRgbffvtts/fp2LEj165dq91WNwd1j+nQoUPt6w4dOlBd/f+rnvE/ZTR4/eijj7J+/XpOnz7NvHnzardfL8Tk9jKsbz+4UAXfSe6ekV9equbL797Hl9v/ntK4bnedz1RS9Mufhvb+rVmc9QG+qPO6DBibaB93rzazr4GsYP3uesf2qf8GZvYYQVd73759UxZ4e9fz1EG+/uAcH60ZcEvn+cW0b4Dc1AQloSopKeHkyZNUVVVRU1PD8uXLWblyJT179qSmpoaqqipisRjl5eU8/PDDbN26lYULF/LOO+8wefLkG841cOBAdu/ezdy5c3nxxReZOnVqbbHWmMrKSnr16kVmZmaDbQUFBaxatYp169Zxzz33sGjRIkaPHt2g8OnevTsXL15MTTKA3r17U1FRQWVlJd26dWP79u0Nfs+bOXnyJLt27SI/P5+NGzcyfvx4AAoLC1m2bBlXr169YSxfXQUFBRQVFbFkyRLcnS1btrBhw4Zb/r0kem71dhyb//g6F/prfEh7k9YTAtx9DbAGYMyYMd7a7xdmFZ1y0+DXK8MOQqKipKSEmTNnMnbsWK5evcrSpUtru+QmTZrEzp07GTduHDNnzmT16tUMGTKEZ555hsWLFzcoWmbPns2UKVMYMGAA+fn5rFmzpsn3Li4uZurUxsfbFBQUsGLFCvLz8+natSuxWIyCgoIG+2VlZXH//fczfPhwpkyZwoIFC5LMRFxmZibLli0jLy+PPn36MHjw4BafY9CgQbz00kvMmzePoUOH8vjjjwPxGaoTJ06kR48eCWfAjho1iqKiIvLy8oD41TZ1aUpjHlo4O+wQpDVcn7ad6h8gH3i3zuungKfq7fMukB8sdwTOAVZ/37r7JfoZPXq0i6Sj0tLSsEPwCRMm+Kefftrotr179/qcOXNueo4HHnjAT5w4kXD7uXPnfP78+d6/f39//vnna9cXFhb64cOHWxxzlJ04ccKHDRvW6LaamhofOXKkHzlypI2jar+i8BkSaSngY09Q07TmlbM9QK6Z5QCniA/wrz/8exvwCPGxZLOA993dzWwbsNHMXiA+ISAX+KgVYxW5rR07dozc3Ma7qEeNGsXEiROpqalp0b3O6svKyuKVV165Yd2VK1eYMWMGAwcOTPq86aS0tJRp06ZRWFiYMN8iIq1WnHl8DNkTxK96ZQDr3P2QmT1HvFrcBqwFNgQD/s8TL+AI9ttMfPJANbDANVNTpNWUlZU1ub3uwPVEioqKGszsvJlOnToxd+7cFh2TDvr169fo0wmGDh3K8ePHQ4hIRNJJq445c/e3gbfrrVtWZ7kK+FmCY1cAK1ozPhFJnaKiorBDEBFpF/R8EBEREZEIUXEmIiIiEiEqzkQiID5xR0RaSp8daY9UnImELBaLUVlZqS8ZkRZydyorKxs8XUIk3aX1TWhF2oPs7GzKyso4e/Zs2KGIpJ1YLEZ2dnbYYYiklIozkZBdf4akiIgIqFtTREREJFJUnImIiIhEiIozERERkQix9jJDzMzOAp+3wVv1Iv6AdkkN5TP1lNPUUj5TTzlNLeUz9doip9939zsb29BuirO2YmYfu/uYsONoL5TP1FNOU0v5TD3lNLWUz9QLO6fq1hQRERGJEBVnIiIiIhGi4qzl1oQdQDujfKaecppaymfqKaeppXymXqg51ZgzERERkQjRlTMRERGRCFFx1kxmNtnMDpvZUTNbEnY87YGZfWZmB8xsv5l9HHY86cjM1plZhZkdrLPuDjN7z8z+G/zbM8wY00mCfD5rZqeCdrrfzH4SZozpxMzuNrNiMys1s0Nm9mSwXm00SU3kVO00CWYWM7OPzKwkyOdvgvU5ZvZh8J3/VzPr1KZxqVvz5swsAzgC/BgoA/YAs929NNTA0pyZfQaMcXfdnydJZjYBuAT8xd2HB+tWAufd/ffBfyR6uvviMONMFwny+Sxwyd1XhRlbOjKzu4C73H2fmXUH9gIzgCLURpPSRE4fQu20xczMgK7ufsnMMoGdwJPAIuAtd99kZq8AJe7+clvFpStnzZMHHHX34+5+BdgETA85JhHc/QPgfL3V04FXg+VXif/hlmZIkE9JkruXu/u+YPki8AnQB7XRpDWRU0mCx10KXmYGPw78CHgjWN/mbVTFWfP0Ab6o87oMfRhSwYEdZrbXzB4LO5h2pLe7lwfLp4HeYQbTTjxhZv8Juj3VBZcEM+sH/BD4ELXRlKiXU1A7TYqZZZjZfqACeA84Bnzl7tXBLm3+na/iTMI03t1HAVOABUGXkqSQx8ctaOzCrXkZ+AFwL1AOrA43nPRjZt2AN4Ffufs3dbepjSankZyqnSbJ3Wvc/V4gm3hP2eCQQ1Jx1kyngLvrvM4O1sktcPdTwb8VwBbiHwq5dWeCcSnXx6dUhBxPWnP3M8Ef72vAn1E7bZFgHM+bwGvu/lawWm30FjSWU7XTW+fuXwHFQD7Qw8w6Bpva/DtfxVnz7AFyg9kbnYCfA9tCjimtmVnXYDArZtYVmAQcbPooaaZtwCPB8iPA1hBjSXvXi4hAIWqnzRYMtl4LfOLuL9TZpDaapEQ5VTtNjpndaWY9guUuxCf+fUK8SJsV7NbmbVSzNZspmJb8ByADWOfuK0IOKa2ZWX/iV8sAOgIbldOWM7PXgQeBXsAZYDnwN2Az0Bf4HHjI3TXIvRkS5PNB4l1FDnwGzK8zXkqaYGbjgX8CB4BrweqlxMdIqY0moYmczkbttMXMbATxAf8ZxC9YbXb354LvqE3AHcC/gTnufrnN4lJxJiIiIhId6tYUERERiRAVZyIiIiIRouJMREREJEJUnImIiIhEiIozERERkQhRcSYiIiISISrORERERCJExZmISCPM7L7gIdKx4IkWh8xseNhxiUj7p5vQiogkYGa/BWJAF6DM3X8XckgichtQcSYikkDwLN09QBUwzt1rQg5JRG4D6tYUEUksC+gGdCd+BU1EpNXpypmISAJmto34w49zgLvc/YmQQxKR20DHsAMQEYkiM5sLXHX3jWaWAfzLzH7k7u+HHZuItG+6ciYiIiISIRpzJiIiIhIhKs5EREREIkTFmYiIiEiEqDgTERERiRAVZyIiIiIRouJMREREJEJUnImIiIhEiIozERERkQj5H7R8erLxuiS7AAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "HQqkOoICk9sv"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from numpyro.handlers import seed, trace, condition\n",
+        "import jax\n",
+        "\n",
+        "def get_samples_and_scores(model, key, batch_size=64, score_type='density', thetas=None):\n",
+        "  \n",
+        "    def log_prob_fn(theta, key):\n",
+        "\n",
+        "        cond_model = condition(model, {'theta': theta})\n",
+        "        cond_model = seed(cond_model, key)\n",
+        "        model_trace = trace(cond_model).get_trace()\n",
+        "\n",
+        "        if score_type == 'density':\n",
+        "            logp = model_trace['theta']['fn'].log_prob(model_trace['theta']['value'])\n",
+        "        elif score_type == 'conditional':\n",
+        "            logp = 0\n",
+        "\n",
+        "        for i in range(len(model_trace) - 1): \n",
+        "          key, val = list(model_trace.items())[i]\n",
+        "          logp += val['fn'].log_prob(val['value'])\n",
+        "\n",
+        "        sample = {'theta': model_trace['theta']['value'],\n",
+        "                  'y': model_trace['y']['value']}\n",
+        "    \n",
+        "        return logp, sample\n",
+        "\n",
+        "    \n",
+        "    # Split the key by batch\n",
+        "    keys = jax.random.split(key, batch_size)\n",
+        "\n",
+        "    # Sample theta from the model\n",
+        "    if thetas == None:\n",
+        "        thetas = jax.vmap(lambda k: trace(seed(model, k)).get_trace()['theta']['value'])(keys)\n",
+        "\n",
+        "    return jax.vmap(jax.value_and_grad(log_prob_fn, has_aux=True))(thetas, keys)"
+      ],
+      "metadata": {
+        "id": "pv7X5xXlveIu"
+      },
+      "execution_count": 129,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def get_batch(key, batch_size=int(5e3)):\n",
+        "    model = galton_board\n",
+        "    (log_probs, samples), scores = get_samples_and_scores(model, key, batch_size=batch_size)\n",
+        "    return samples['theta'], samples['y'], scores\n",
+        "\n",
+        "mu, batch, grad = get_batch(jax.random.PRNGKey(62))"
+      ],
+      "metadata": {
+        "id": "MhENCHbzZYOp"
+      },
+      "execution_count": 130,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "t_, x_, score0___, pos0, log0 = simulate(simulator_name = 'galton',\n",
+        "            sample_label = 'train', \n",
+        "            theta0=None,\n",
+        "            single_theta=True, \n",
+        "            generate_joint_ratio=False,\n",
+        "            generate_joint_score=True,\n",
+        "            n_thetas=5e3,\n",
+        "            n_samples_per_theta=1, \n",
+        "            score = 'density')"
+      ],
+      "metadata": {
+        "id": "K6njMyWVeFEM"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "plt.hist(grad, alpha = 0.5, density = True, label = 'gradients form numpyro simulator');\n",
+        "plt.hist(score0___.squeeze(), alpha = 0.5, density = True, label = 'gradients from mining gold simulator');\n",
+        "plt.legend()\n",
+        "plt.title('check gradients of numpyro simulator')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 407
+        },
+        "id": "5uLgSOT7hOug",
+        "outputId": "5b8875df-36c5-4000-dace-46842b0fcbc9"
+      },
+      "execution_count": 138,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "Text(0.5, 1.0, 'check gradients of numpyro simulator')"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 138
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 576x432 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAewAAAF1CAYAAAAqQ9nrAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3de5hWdb3//+dbQNBko1vJA4iAp40wCDocPKBoimgq6U9/YWKaB6IdZe48lttT9c3Mb3Yyzco0MzERi0wvtdTU0hjQAcQjGAnk9oBHAkzw8/1jrZl9M9wzcwMDM2vm+biuubjvdbrfn7XWzOtea31YK1JKSJKktm2z1i5AkiQ1z8CWJKkADGxJkgrAwJYkqQAMbEmSCsDAliSpAAxsbVQRcVpEPLYRlrswIg5r6eWuj4i4KSK+nr8eFRHPt3ZNTYmILSLidxHxTkTc0dr1tDUR8ZWI+OlGWvbDEXHmxli22j8DW2pBKaVHU0p7tsSyNuKXkhOA7YFtU0onboTlF1pK6f+klFo9VNvSl1K1DQa2VCIiOrd2DZvALsALKaVVrV1IS4mMf89yHWQ/7nDcwdUiImLniJgWEa9HxNKI+GGD8VdHxFsR8beIOLJkeI+I+FlEvBIRSyLi6xHRqWT8WRHxbES8FxHPRMQ+ZT57QL7ckxqpbUxEPJ+fAv5RRPyp7rRkfsr+zxFxTUQsBS6LiF0j4sG8HW9ExK0RsXXJ8oZGxJN5TbcD3UrGjY6IxSXvd4qIO/P18reI+GLJuMsi4tcR8Yt8WfMiojofdwvQB/hdRCyLiPMjoltE/DKv6+2IqImI7Rtp84D89Ovb+XKPzYdfDlwCfDJf7hll5m20rnx8iojdSt6XXhIYHRGL83pfy7frJyLiqIh4ISLejIivNPisqRFxe/5ZT0bE3vm48yLizga1fT8ivpe/fjgivhERfwaWA/0jYv98vbyT/7t/ufWTz39Bvs+9l+8fHyup6Zf56755ez8TEYvyfXhSRAyLiDn5+v1hyTLr520w/1oB2tR+Vm7758OPzbfH23n7B5Qsb2HepjnAP8t9pgoupeSPPxv0A3QCZgPXAB8hC7AD83GnAR8AZ+XTfQ74BxD5+LuAH+fzfRSYAXw2H3cisAQYBgSwG7BLPm4hcBiwD/AycHQjtW0HvAscD3QGzs7rObOkvlXAF/LxW+SfczjQFegJPAJ8N59+c+DvwDlAF7LTyx8AX8/HjwYW5683A2aRBeTmQH/gJeCIfPxlwErgqHzdfBN4oqT2hcBhJe8/C/wO2DKffl/g38q0uQswH/hK/rmHAu8Be5Z87i+b2J7N1ZWA3Ure39Sg/avyNnfJt/vrwK+A7sBAYAXQr+SzPsjXYxfgXOBv+esdgX8CW+fTdgZeA/bN3z+cb/uB+bjtgbeAU/L3J+Xvty3Txj2BRcBO+fu+wK4N108+PAHXk+3XY/J18xuy/bVXXtPB5dZtyfydS2qu2/ca3c8a2f575Ovj8Hz9nJ9v581Lpq8Fdga2aO2/C/60/I9H2GoJw4GdgPNSSv9MKa1MKZV2NPt7SuknKaXVwM1kf4i3z48OjwK+lM/3Glnoj8/nOxO4KqVUkzLzU0p/L1nuKGA68OmU0t2N1HYUMC+lNC1lp4C/D/xPg2n+kVL6QUppVUppRf45D6SU3k8pvQ58Bzg4n3Yk2R/L76aUPkgpTQVqGvnsYUDPlNIVKaV/pZReAn5S0j6Ax1JK9+Tr5hZg70aWBVmwbUsWlqtTSrNSSu+WmW4ksBVwZf65DwJ3kwVYpdalrnJ1fiOl9AEwhexL0/dSSu+llOYBzzRY3qyU0tR8+u+QBePIlNIrZCFWd519LPBGSmlWybw3pZTm5dt2DPBiSumWfFveBjwHHFOmxtVkQblXRHRJKS1MKS1ook1fy/fr+8lC87aU0msppSXAo8DQdVg/ADSzn5XzSeD3+TwfAFeTfcEsPYvw/ZTSopTSinWtR22fp0zUEnYmC+XGronWB2RKaXlEQBYo/04Wfq/kwyA7Kl1Ustym/ohOAv6UUnq4iWl2KlkeKaVUeso6t6j0Tf5F4ntkXwi65zW9VbK8JSml0qfmlH6JKLULsFNEvF0yrBPZH/g6pV8elgPdIqJzI+vyFrJ1MiU/dfpL4Kv5H+9SOwGLUkofNqixVyN1lrMudTW0NA96yI6mAV4tGb+CbPvXKd0+H+bbZ6d80M1kZ2V+AkwgWweUmzefp+G2KNvulNL8iPgS2RHxwIi4D/ivlNI/GmlTw/qbak9FmtnPylmjffm6WsSa7Vu01lxqNzzCVktYBPRZj2tmi4D3ge1SSlvnP/+WUhpYMn7XJuaflH/uNU1M8wrQu+5NZN8MejeYpuEj6/5PPqwqpfRvZEFR943iFaBXlHzDILvWWM4i4G8lbds6pdQ9pXRUE/U2Wld+RH95SmkvsqOqo4FPl5nvH8DOsWYnrD5klxdawnKy0/J1dtjA5e1c9yKvuTdZGyA79Tw4IgaRtffWBvOWrqN/kH1JKtVou1NKv0opHZjPk4BvrW8DSvyTytdNU/sZrL1frtG+fB/cmTXb5+MX2zEDWy1hBlmQXRkRH8k7Rx3Q3Ez5Kc/7gf8bEf8WEZvlHXHqTgv+FDg3IvaNzG4RUfoH+T2y06QHRcSVjXzM74GqvONTZ+DzNB8w3YFlwDsR0Qs4r2Tc42TXaL8YEV0i4niySwLlzADeyzsCbRERnSJiUEQMa+bz67xKdt0bgIg4JCKqIuuU9y7ZqecPy8z3V7JQPT+vcTTZaeEpFX5uc2qBT+XtGUvTp3ErsW9EHJ9vny+RfYl7AiCltBKYSnYNfEZK6eUmlnMPsEdEfCoiOkfEJ4G9yC4HrCEi9oyIQyOiK9k16RWUX5frqpZsf+wTET2Ai5qYtqn9DBpsf+DXwMcj4mMR0QX4Mtm6+ksL1K0CMLC1wfLTn8eQdaJ5GVhMdr2tEp8m6xj1DNnpwKlk17hJKd0BfIPsj/V7ZEdb/97gs98m64RzZER8rUxtb5BdA70KWEr2B3wm2R+6xlxO1pntHbLAn1ayvH+RdWA7DXgzb+e0tRdRv16OBoaQdaR6g+xLSI8mPrvUN4GL8x7B55J90ZhKFtbPAn9i7VPEdTUeAxyZf+aPyK7zP1fh5zbn7Hz5bwMnk22XDfFbsvVY12Hs+Aan+W8GqijT1lIppaVk6/vLZNv6fLLOiG+UmbwrcCXZ+vkfsg5kTYVrRVJKDwC3A3PIOhw21rcCmtjPcmts/5TS82RH4T/I6z4GOCbf3uoA6nrqSh1Cfsp1MXBySumh1q6no4uIy8g60U1oYpo+ZJ3Hdmikk53UIXiErXYvIo6IiK3z059fIbtO+EQrl6UK5F+w/guYYliro7OXuDqC/chOq9edev+E/+2l7YuIj5Bdx/07WV8FqUPzlLgkSQXgKXFJkgrAwJYkqQDa3DXs7bbbLvXt27e1y5AkaZOZNWvWGymlnk1N0+YCu2/fvsycObO1y5AkaZOJiMZucVzPU+KSJBWAgS1JUgEY2JIkFUCbu4ZdzgcffMDixYtZuXJla5cidRjdunWjd+/edOnSpbVLkURBAnvx4sV0796dvn37suZTDSVtDCklli5dyuLFi+nXr19rlyOJgpwSX7lyJdtuu61hLW0iEcG2227rWS2pDSlEYAOGtbSJ+TsntS2FCez2pm/fvrzxRvaY3v3333+9l3PTTTfxj3/8o+Lp33//fQ477DCGDBnC7bffvt6f2xHNnDmTL37xiy2yrJtuuonJkyc3Oc3DDz/MX/7ylxb5PEnFV4hr2A1d88ALLbq8cw7fo0WWs2rVKjp3XvdVuiF/lG+66SYGDRrETjvtVNH0Tz31FAC1tbUVf8bq1avp1KnTetXX1qzvNgKorq6murq6hStq3MMPP8xWW221Tl/oNqR9kto2j7Ar9LWvfY0999yTAw88kJNOOomrr74agNGjR/OlL32J6upqvve97/G73/2OESNGMHToUA477DBeffVVAJYuXcqYMWMYOHAgZ555JqVPSdtqq63qX3/7299m2LBhDB48mEsvvRSAhQsXMmDAAM466ywGDhzImDFjWLFiBVOnTmXmzJmcfPLJDBkyhBUrVnDhhRey1157MXjwYM4999w12vDaa68xYcIEampqGDJkCAsWLOCPf/wjQ4cOpaqqitNPP533338fyM4AXHDBBeyzzz7ccccd9O3bl4suuoghQ4ZQXV3Nk08+yRFHHMGuu+7K9ddfv9b6aqzmunVWdze7N954g7pb0d5000184hOf4PDDD6dv37788Ic/5Dvf+Q5Dhw5l5MiRvPnmm/Xzn3322QwZMoRBgwYxY8YMPvzwQ3bffXdef/11AD788EN22203Xn/9dU477TQmTZrEiBEjOP/886mtrWXkyJEMHjyY4447jrfeemut+u+44w4GDRrE3nvvzUEHHQRkAXr00UcDcNlll3HqqacyatQodtllF6ZNm8b5559PVVUVY8eO5YMPPqhfj3VnUmbOnMno0aPX+qxy+8zChQu5/vrrueaaaxgyZAiPPvooCxcu5NBDD2Xw4MF87GMf4+WXXwZYq32S2icDuwI1NTXceeedzJ49m3vvvXetW6f+61//YubMmXz5y1/mwAMP5IknnuCpp55i/PjxXHXVVQBcfvnlHHjggcybN4/jjjuu/o9tqfvvv58XX3yRGTNmUFtby6xZs3jkkUcAePHFF/n85z/PvHnz2Hrrrbnzzjs54YQTqK6u5tZbb6W2tpbly5dz1113MW/ePObMmcPFF1+8xvI/+tGP8tOf/pRRo0ZRW1tLr169OO2007j99tuZO3cuq1at4rrrrqufftttt+XJJ59k/PjxAPTp04fa2lpGjRrFaaedxtSpU3niiSfqv1g0VK7m5jz99NNMmzaNmpoavvrVr7Llllvy1FNPsd9++/GLX/yifrrly5dTW1vLj370I04//XQ222wzJkyYwK233grAH/7wB/bee2969sxuzbt48WL+8pe/8J3vfIdPf/rTfOtb32LOnDlUVVVx+eWXr1XHFVdcwX333cfs2bOZPn162VoXLFjAgw8+yPTp05kwYQKHHHIIc+fOZYsttuD3v/99s22tU26f6du3L5MmTeKcc86pX+df+MIXOPXUU5kzZw4nn3zyGqfnS9snqX0ysCvw5z//mXHjxtGtWze6d+/OMcccs8b4T37yk/WvFy9ezBFHHEFVVRXf/va3mTdvHgCPPPIIEyZMAODjH/8422yzzVqfc//993P//fczdOhQ9tlnH5577jlefPFFAPr168eQIUMA2HfffVm4cOFa8/fo0YNu3bpxxhlnMG3aNLbccssm2/X888/Tr18/9tgjuyRw6qmn1n9BaNgugGOPPRaAqqoqRowYQffu3enZsyddu3bl7bffXmv5ldTc0CGHHFK/3B49etSv66qqqjXmP+mkkwA46KCDePfdd3n77bc5/fTT60P9xhtv5DOf+Uz99CeeeCKdOnXinXfe4e233+bggw8u2+Y6BxxwAKeddho/+clPWL16ddlajzzySLp06UJVVRWrV69m7NixZWttTmP7TEOPP/44n/rUpwA45ZRTeOyxx9Zqn6T2y8BuAR/5yEfqX3/hC19g8uTJzJ07lx//+Mfr9N9iUkpcdNFF1NbWUltby/z58znjjDMA6Nq1a/10nTp1YtWqVWvN37lzZ2bMmMEJJ5zA3XffXR8g66u0XaU1bLbZZmvUs9lmm5Wtp7GaO3fuzIcffgiw1vppuNzSzyz9jIY9mCOCnXfeme23354HH3yQGTNmcOSRRzbaluZcf/31fP3rX2fRokXsu+++LF26tNH2bbbZZnTp0qW+ptJam2prnQ3ZZ+qsa/skFY+9UypwwAEH8NnPfpaLLrqIVatWcffddzNx4sSy077zzjv06tULgJtvvrl++EEHHcSvfvUrLr74Yu69996y102POOII/vu//5uTTz6ZrbbaiiVLljR7l6nu3bvz3nvvAbBs2TKWL1/OUUcdxQEHHED//v2bnHfPPfdk4cKFzJ8/n912241bbrml/shzY+rbty+zZs1i+PDhTJ06db2Wcfvtt3PIIYfw2GOP0aNHD3r06AHAmWeeyYQJEzjllFPKHnH26NGDbbbZhkcffZRRo0Y12uYFCxYwYsQIRowYwb333suiRYvWq866th555JGNXhJobJ/p3r077777bv37/fffnylTpnDKKadw6623MmrUqPWqqSNq6Y6qG6qlOrqqY/EIuwLDhg3j2GOPZfDgwRx55JFUVVXVB0RDl112GSeeeCL77rsv2223Xf3wSy+9lEceeYSBAwcybdo0+vTps9a8Y8aM4VOf+hT77bcfVVVVnHDCCfVh3Ji6DkdDhgzhvffe4+ijj2bw4MEceOCBzV7P7NatGz//+c858cQTqaqqYrPNNmPSpEkVrJENc+6553LdddcxdOjQ+g5Z66pbt24MHTqUSZMm8bOf/ax++LHHHsuyZcvWOB3e0M0338x5553H4MGDqa2t5ZJLLllrmvPOO4+qqioGDRrE/vvvz957771edV566aWcffbZVFdXN3rKurF95phjjuGuu+6q73T2gx/8gJ///OcMHjyYW265he9973vrVZOkYorS3sptQXV1dWrYqevZZ59lwIABrVRRZtmyZWy11VYsX76cgw46iBtuuIF99tmnVWvqqEaPHs3VV19d9r9YzZw5k3POOYdHH320FSprf9rC715L8AhbbV1EzEopNfn/Rj0lXqGJEyfyzDPPsHLlSk499VTDug268sorue666+p7iktSe2JgV+hXv/pVa5eg3MMPP1x2+IUXXsiFF164aYuRpE3Ea9iSJBWAgS1JUgEY2JIkFYCBLUlSARjYrcTHa2auv/76Ne4RXk5LPtZyXS1cuJBBgwaVHVf6EJPmVNLOStXdx70p67pfSGr7itlL/KFvtuzyDrmoRRZT9MdrtsZjNCu5UcumfqzlxrApbkhTal33C2hfj1GV2iOPsCvUXh+v2fAxmrfddlv9Hb4uuOCCNWo877zzGDhwIIcddhgzZsxg9OjR9O/fv+zTrB5++GEOPvhgxo0bR//+/bnwwgu59dZbGT58OFVVVSxYsADI7vJVui4vuOAChg8fzh577FF/85OGj7U8/fTT6z/7+9//frPbqNSCBQsYOXIkVVVVXHzxxfXrPqXEeeedx6BBg6iqqip79mHFihWMHz+eAQMGcNxxx9U/LrShctugYTvPOeccqqurGTBgADU1NRx//PHsvvvu9U9Ya3hkf/XVV3PZZZet9VlXXHEFw4YNY9CgQUycOJGUUtn9otLHqEpquwzsCrTXx2vuuuuuwP8+RvOggw7iggsu4MEHH6S2tpaamhp+85vfAPDPf/6TQw89lHnz5tG9e3cuvvhiHnjgAe66666yt/YEmD17Ntdffz3PPvsst9xyCy+88AIzZszgzDPP5Ac/+EHZeVatWsWMGTP47ne/W/axlwDPPfcc9913HzNmzODyyy/ngw8+aHYb1Tn77LM5++yzmTt3Lr17964fPm3aNGpra5k9ezZ/+MMfOO+883jllVfWmPe6665jyy235Nlnn+Xyyy9n1qxZay1/6dKlTW6DOptvvjkzZ85k0qRJjBs3jmuvvZann36am266qeyDRhozefJkampqePrpp1mxYgV33333WvtFRKzTY1QltU0GdgXa6+M1G9ZfU1PD6NGj6dmzJ507d+bkk0+u/8Kw+eabr/H4yIMPPrj+0ZKNPUpy2LBh7LjjjnTt2pVdd92VMWPG1M/f2DzHH398k22EbP117dqV7bbbjo9+9KO8+uqrzW6jOo8//jgnnngiQP2jKgEee+wxTjrpJDp16sT222/PwQcfTE1NzRrzlm7DwYMHM3jw4LWWX+k2KH1U6cCBA+vXU//+/dfpQSMPPfQQI0aMoKqqigcffLDsoznX9TGqktomA7sFFP3xmpU8mrHh4yMbe+xlqUoflVlunsba2HC5TU3XGirdBs09qrT0sZxQ/tGcK1eu5D//8z+ZOnUqc+fO5ayzzvLRnFI7ZmBX4IADDuB3v/sdK1euZNmyZdx9992NTtvc4zWBJh+veeONN7Js2TIAlixZwmuvvdZkbQ0fr/nOO+9w1FFHcc011zB79ux1aufw4cP505/+xBtvvMHq1au57bbbNsnjNltCpdto5MiR9Y+5nDJlSv3wUaNGcfvtt7N69Wpef/11HnnkEYYPH77GvKXb8Omnn2bOnDlrLX9Dt0Gd7bffntdee42lS5fy/vvvl21PXThvt912LFu2bI2e46X7ReljVIFN9hhVSS2rmL3EN7HSx2tuv/32FT1ec5tttuHQQw/lb3/7G5A9ZvGkk05i4MCB7L///o0+XvPZZ59lv/32A7KOXr/85S+b7Llb93jNLbbYgnvvvZdx48axcuVKUkrNPl6zoR133JErr7ySQw45hJQSH//4xxk3btw6LaO1VLqNvvvd7zJhwgS+8Y1vMHbs2PppjjvuOB5//HH23ntvIoKrrrqKHXbYYY3T8p/73Of4zGc+w4ABAxgwYAD77rvvWst/7733Nmgb1OnSpQuXXHIJw4cPp1evXvzHf/zHWtNsvfXWnHXWWQwaNIgddtiBYcOG1Y8r3S8ef/zx+seorlq1imHDhm3yXuuSNpyP16yQj9ds+yrZRsuXL2eLLbYgIpgyZQq33XYbv/3tb1up4ravLfzutQQfr6m2zsdrtiAfr9n2VbKNZs2axeTJk0kpsfXWW3PjjTe2QqWStO4M7Ar5eM22r5JtNGrUqPW+rixJrclOZ5IkFUBhArutXWuX2jt/56S2pRCB3a1bN5YuXeofEGkTSSmxdOlSunXr1tqlSMoV4hp27969Wbx4Ma+//nprlyJ1GN26dVvj9q2SWlchArtLly7069evtcuQJKnVFOKUuCRJHZ2BLUlSAVQU2BExNiKej4j5EXFhmfH/FRHPRMSciPhjROxSMm51RNTmP2s/OFmSJDWr2WvYEdEJuBY4HFgM1ETE9JTSMyWTPQVUp5SWR8TngKuAumf2rUgpDWnhuiVJ6lAqOcIeDsxPKb2UUvoXMAVY44kQKaWHUkrL87dPAHYtlSSpBVXSS7wXsKjk/WJgRBPTnwHcW/K+W0TMBFYBV6aUfrPOVUpScx76ZqOjRr68dBMWsrYn+kxs1c9X+9Ci/60rIiYA1UDpw3Z3SSktiYj+wIMRMTeltKDBfBOBiUDZx05KktTRVXJKfAmwc8n73vmwNUTEYcBXgWNTSu/XDU8pLcn/fQl4GBjacN6U0g0ppeqUUnXPnj3XqQGSJHUElQR2DbB7RPSLiM2B8cAavb0jYijwY7Kwfq1k+DYR0TV/vR1wAFDaWU2SJFWg2VPiKaVVETEZuA/oBNyYUpoXEVcAM1NK04FvA1sBd0QEwMsppWOBAcCPI+JDsi8HVzboXS5JkipQ0TXslNI9wD0Nhl1S8vqwRub7C1C1IQVKkiTvdCZJUiEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBVBTYETE2Ip6PiPkRcWGZ8f8VEc9ExJyI+GNE7FIy7tSIeDH/ObUli5ckqaNoNrAjohNwLXAksBdwUkTs1WCyp4DqlNJgYCpwVT7vvwOXAiOA4cClEbFNy5UvSVLHUMkR9nBgfkrppZTSv4ApwLjSCVJKD6WUludvnwB656+PAB5IKb2ZUnoLeAAY2zKlS5LUcVQS2L2ARSXvF+fDGnMGcO96zitJksro3JILi4gJQDVw8DrONxGYCNCnT5+WLEmSpHahkiPsJcDOJe9758PWEBGHAV8Fjk0pvb8u86aUbkgpVaeUqnv27Flp7ZIkdRiVBHYNsHtE9IuIzYHxwPTSCSJiKPBjsrB+rWTUfcCYiNgm72w2Jh8mSZLWQbOnxFNKqyJiMlnQdgJuTCnNi4grgJkppenAt4GtgDsiAuDllNKxKaU3I+JrZKEPcEVK6c2N0hJJktqxiq5hp5TuAe5pMOySkteHNTHvjcCN61ugJEnyTmeSJBWCgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVQEWBHRFjI+L5iJgfEReWGX9QRDwZEasi4oQG41ZHRG3+M72lCpckqSPp3NwEEdEJuBY4HFgM1ETE9JTSMyWTvQycBpxbZhErUkpDWqBWSZI6rGYDGxgOzE8pvQQQEVOAcUB9YKeUFubjPtwINUqS1OFVckq8F7Co5P3ifFilukXEzIh4IiI+sU7VSZIkoLIj7A21S0ppSUT0Bx6MiLkppQWlE0TERGAiQJ8+fTZBSZIkFUslR9hLgJ1L3vfOh1UkpbQk//cl4GFgaJlpbkgpVaeUqnv27FnpoiVJ6jAqCewaYPeI6BcRmwPjgYp6e0fENhHRNX+9HXAAJde+JUlSZZoN7JTSKmAycB/wLPDrlNK8iLgiIo4FiIhhEbEYOBH4cUTMy2cfAMyMiNnAQ8CVDc2qUWwAAA3hSURBVHqXS5KkClR0DTuldA9wT4Nhl5S8riE7Vd5wvr8AVRtYoyRJHZ53OpMkqQAMbEmSCsDAliSpAAxsSZIKwMCWJKkADGxJkgrAwJYkqQAMbEmSCsDAliSpAAxsSZIKwMCWJKkADGxJkgrAwJYkqQAMbEmSCsDAliSpAAxsSZIKwMCWJKkADGxJkgrAwJYkqQA6t3YBktTejXz5hjUHPLRt6xRSziEXtXYFqpBH2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgH437oktahrHnihVT535MtLW+VzpU3FI2xJkgrAwJYkqQAMbEmSCsDAliSpAAxsSZIKwMCWJKkADGxJkgrAwJYkqQAMbEmSCsDAliSpAAxsSZIKwMCWJKkADGxJkgrAwJYkqQAMbEmSCsDAliSpAAxsSZIKoHNrFyCpQB76ZrOTjHx56SYoROp4PMKWJKkADGxJkgqgosCOiLER8XxEzI+IC8uMPyginoyIVRFxQoNxp0bEi/nPqS1VuCRJHUmzgR0RnYBrgSOBvYCTImKvBpO9DJwG/KrBvP8OXAqMAIYDl0bENhtetiRJHUslR9jDgfkppZdSSv8CpgDjSidIKS1MKc0BPmww7xHAAymlN1NKbwEPAGNboG5JkjqUSgK7F7Co5P3ifFglNmReSZKUaxOdziJiYkTMjIiZr7/+emuXI0lSm1NJYC8Bdi553zsfVomK5k0p3ZBSqk4pVffs2bPCRUuS1HFUEtg1wO4R0S8iNgfGA9MrXP59wJiI2CbvbDYmHyZJktZBs4GdUloFTCYL2meBX6eU5kXEFRFxLEBEDIuIxcCJwI8jYl4+75vA18hCvwa4Ih8mSZLWQUW3Jk0p3QPc02DYJSWva8hOd5eb90bgxg2oUZLalcdfaju3b31i1QsAnHP4Hq1ciZrTJjqdSZKkphnYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgFUFNgRMTYino+I+RFxYZnxXSPi9nz8XyOibz68b0SsiIja/Of6li1fkqSOoXNzE0REJ+Ba4HBgMVATEdNTSs+UTHYG8FZKabeIGA98C/hkPm5BSmlIC9ctSVKHUskR9nBgfkrppZTSv4ApwLgG04wDbs5fTwU+FhHRcmVKktSxVRLYvYBFJe8X58PKTpNSWgW8A2ybj+sXEU9FxJ8iYtQG1itJUofU7CnxDfQK0CeltDQi9gV+ExEDU0rvlk4UEROBiQB9+vTZyCVJklQ8lRxhLwF2LnnfOx9WdpqI6Az0AJamlN5PKS0FSCnNAhYAezT8gJTSDSml6pRSdc+ePde9FZIktXOVBHYNsHtE9IuIzYHxwPQG00wHTs1fnwA8mFJKEdEz77RGRPQHdgdeapnSJUnqOJo9JZ5SWhURk4H7gE7AjSmleRFxBTAzpTQd+BlwS0TMB94kC3WAg4ArIuID4ENgUkrpzY3REEmS2rOKrmGnlO4B7mkw7JKS1yuBE8vMdydw5wbWKElSh7exO51J2oiueeCFTfp5I19eukk/T9L/8takkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAz8OW2pqHvlnxpD6fWuo4PMKWJKkADGxJkgrAwJYkqQAMbEmSCsDAliSpAAxsSZIKwMCWJKkADGxJkgrAwJYkqQAMbEmSCsDAliSpAAxsSZIKwMCWJKkADGxJkgrAwJYkqQAMbEmSCsDAliSpAAxsSZIKwMCWJKkADGxJkgrAwJYkqQAMbEmSCqBzaxcgFck1D7yw0T9j5MtLN/pnSCoej7AlSSoAA1uSpAIwsCVJKgADW5KkArDTmTqmh765XrPZIUxSazGwJakDG/nyDdmLh7Zt3ULKOeSi1q6gTTGwJUk8/lLbO3u03yGtXUHbUtE17IgYGxHPR8T8iLiwzPiuEXF7Pv6vEdG3ZNxF+fDnI+KIlitdkqSOo9kj7IjoBFwLHA4sBmoiYnpK6ZmSyc4A3kop7RYR44FvAZ+MiL2A8cBAYCfgDxGxR0ppdUs3RO3PxrxJideiJRVNJafEhwPzU0ovAUTEFGAcUBrY44DL8tdTgR9GROTDp6SU3gf+FhHz8+U93jLlq01bz45ddQxVSfpflQR2L2BRyfvFwIjGpkkprYqId4Bt8+FPNJi313pXq41mYxzNGriSNsgGfunfqFqhQ1yb6HQWEROBifnbZRHx/CYuYTvgjU38mRtLe2oL2J62rD21BdpXe9pTW6BNtucr6ztjY23ZpbkZKwnsJcDOJe9758PKTbM4IjoDPYClFc5LSukG4IYKatkoImJmSqm6tT6/JbWntoDtacvaU1ugfbWnPbUF2ld7NqQtlfQSrwF2j4h+EbE5WSey6Q2mmQ6cmr8+AXgwpZTy4ePzXuT9gN2BGetTqCRJHVmzR9j5NenJwH1AJ+DGlNK8iLgCmJlSmg78DLgl71T2Jlmok0/3a7IOaquAz9tDXJKkdVfRNeyU0j3APQ2GXVLyeiVwYiPzfgP4xgbUuCm02un4jaA9tQVsT1vWntoC7as97akt0L7as95tiezMtSRJast8WpckSQXQYQI7Ik6MiHkR8WFEVJcMPzwiZkXE3PzfQxuZ/7KIWBIRtfnPUZuu+rVqKduWfFyzt4LNOxD+NZ/u9rwzYZuQ11O3jhdGRG0j0y3Mt1ltRMzc1HVWotJ9prlb/7YVEfHtiHguIuZExF0RsXUj07XZbbMht1luayJi54h4KCKeyf8enF1mmtER8U7JPnhJuWW1Fc3tO5H5fr595kTEPq1RZ3MiYs+SdV4bEe9GxJcaTLPu2yal1CF+gAHAnsDDQHXJ8KHATvnrQcCSRua/DDi3tdvRTFv2AmYDXYF+wAKgU5n5fw2Mz19fD3yutdvUSDv/L3BJI+MWAtu1do3N1N/sPkPWkXMB0B/YPN9+e7V27Y3UOgbonL/+FvCtIm2bStY18J/A9fnr8cDtrV13E+3ZEdgnf90deKFMe0YDd7d2revQpib3HeAo4F4ggJHAX1u75gra1An4H2CXDd02HeYIO6X0bEpprRuypJSeSin9I387D9giIrpu2urWTWNtoeRWsCmlvwF1t4Ktl98y9lCyW8gC3Ax8YmPWuz7yOv9/4LbWrmUjq7/1b0rpX0DdrX/bnJTS/SmlVfnbJ8juq1AklazrcWS/E5D9jnws3xfbnJTSKymlJ/PX7wHP0v7vJDkO+EXKPAFsHRE7tnZRzfgYsCCl9PcNXVCHCewK/X/Akym793k5k/PTMDdGxDabsrAKlbuNbMNf4G2Bt0v+8LbV28WOAl5NKb3YyPgE3J9fxpjYyDRtQXP7TCXbrC06nexIp5y2um0qWddr3GYZqLvNcpuWn7ofCvy1zOj9ImJ2RNwbEQM3aWHrrrl9p4i/L+Np/MBjnbZNm7g1aUuJiD8AO5QZ9dWU0m+bmXcg2Wm+MY1Mch3wNbId6mtkp2tPX/9qm7YhbWnrKmzbSTR9dH1gSmlJRHwUeCAinkspPdLStTanqbawifeZllDJtomIr5LdV+HWRhbTJrZNRxERWwF3Al9KKb3bYPSTZKdil+V9KH5DdgOrtqpd7Tt5/6BjgXI3Hl/nbdOuAjuldNj6zBcRvYG7gE+nlBY0suxXS6b/CXD3ehVZofVsSyW3gl1Kdhqpc34EUfZ2sRtTc22L7Pa2xwP7NrGMJfm/r0XEXWSnOzf5L3al26mJfaai2/duKhVsm9OAo4GPpfxCXJlltIltU8aG3Ga5TYqILmRhfWtKaVrD8aUBnlK6JyJ+FBHbpZTa2H25MxXsO23q96UCR5KdtX214Yj12TYd/pR43tP198CFKaU/NzFd6XWS44CnN3Zt66HZW8Hmf2QfIruFLGS3lG1rR+yHAc+llBaXGxkRH4mI7nWvyc6KtLntUeE+U8mtf9uEiBgLnA8cm1Ja3sg0bXnbbMhtltuc/Nr6z4BnU0rfaWSaHequwUfEcLK/+W3yC0iF+8504NN5b/GRwDsppVc2canrotEzheu1bVq7B92m+iH7g7kYeB94FbgvH34x8E+gtuTno/m4n5L3wgZuAeYCc8h2mh3bWlvycV8l6wn7PHBkyfB7+N/e8P3Jgnw+cAfQtbW3T4P23QRMajBsJ+Cekvpn5z/zyE7XtnrdZdpRdp8pbUv+/iiyHr4L2mpb8jrnk10/rPs9qetNXZhtU25dA1eQfQkB6Jb/TszPf0f6t3bNTbTlQLLLLXNKtslRwKS63x9gcr4dZpN1FNy/tetuoj1l950G7Qng2nz7zaXkf8m0tR/gI2QB3KNk2AZtG+90JklSAXT4U+KSJBWBgS1JUgEY2JIkFYCBLUlSARjYkiQVgIEtSVIBGNiSJBWAgS1JUgH8P/swZ+lpah2OAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/sbids/tasks/galtonboard.py
+++ b/sbids/tasks/galtonboard.py
@@ -1,0 +1,63 @@
+import jax.numpy as jnp
+import numpyro
+import numpyro.distributions as dist
+from numpyro.contrib.control_flow import cond
+
+
+__all__=["galton_board"]
+
+def sigmoid_(x):
+    return 1. / (1. + jnp.exp(-x))
+
+def nail_positions(theta, n_rows, n_nails, level, nail):
+    """
+    Compute the probability p(zh, zv, θ) of going left. 
+    
+    Args:
+        theta: parameter used for the probability of bouncing to the left
+        n_rows: number of rows in the galton board
+        n_nails: number of nails in the galton board
+        level: current row
+        nail: current nail
+    """
+
+    level_rel = 1. * level / (n_rows - 1) #zv
+    nail_rel = 2. * nail / (n_nails - 1) - 1. #zh
+
+    nail_positions = ((1. - jnp.sin(jnp.pi * level_rel)) * 0.5
+                      + jnp.sin(jnp.pi * level_rel) * sigmoid_(10 * theta * nail_rel))
+    
+    res = cond(level % 2 == 1 and nail == 0, 
+                       lambda _: 0.0, 
+                       lambda _: cond(level % 2 == 1 and nail == n_nails, 
+                                                 lambda _: 1.0, 
+                                                 lambda _: nail_positions, 
+                                                 0), 
+                       0)
+
+    return nail_positions
+
+def galton_board(y = None,  n_rows = 20, n_nails = 31):
+  """
+  Probabilistic model for the Generalized Galton Board example as described
+  in https://github.com/johannbrehmer/simulator-mining-example.
+
+  Args:
+    y: bin in which the ball ends up 
+    n_rows: number of rows in the galton board
+    n_nails: number of nails in the galton board
+  """
+
+  theta = numpyro.sample('theta', dist.Uniform(-1, 0))
+  pos = n_nails // 2
+
+  for level in range(n_rows):
+    pos = numpyro.sample('z%d' %level,  
+                      dist.TransformedDistribution(dist.Bernoulli(1 - nail_positions(theta, n_rows, n_nails, level, pos)), 
+                                              dist.transforms.AffineTransform( - (level % 2) + pos, 1)))
+  y = numpyro.sample("y", 
+                      dist.TransformedDistribution(dist.Bernoulli(1 - nail_positions(theta, n_rows, n_nails, level, pos)), 
+                                              dist.transforms.AffineTransform( - (level % 2) + pos, 1)), 
+                      obs=y)
+
+  return y

--- a/sbids/tasks/galtonboard.py
+++ b/sbids/tasks/galtonboard.py
@@ -35,7 +35,7 @@ def nail_positions(theta, n_rows, n_nails, level, nail):
                                                  0), 
                        0)
 
-    return nail_positions
+    return res
 
 def galton_board(y = None,  n_rows = 20, n_nails = 31):
   """

--- a/sbids/tasks/utils.py
+++ b/sbids/tasks/utils.py
@@ -23,7 +23,7 @@ def get_samples_and_scores(model, key, batch_size=64, score_type='density', thet
         elif score_type == 'conditional':
             logp = 0
 
-        for i in range(len(model_trace) - 1): 
+        for i in range(1, len(model_trace)): 
           key, val = list(model_trace.items())[i]
           logp += val['fn'].log_prob(val['value'])
 

--- a/sbids/tasks/utils.py
+++ b/sbids/tasks/utils.py
@@ -18,18 +18,17 @@ def get_samples_and_scores(model, key, batch_size=64, score_type='density', thet
         cond_model = seed(cond_model, key)
         model_trace = trace(cond_model).get_trace()
 
-        if score_type == 'density':
-            logp = model_trace['theta']['fn'].log_prob(model_trace['theta']['value'])
-        elif score_type == 'conditional':
-            logp = 0
-
-        for i in range(1, len(model_trace)): 
+        logp = 0 
+        for i in range(len(model_trace)): 
           key, val = list(model_trace.items())[i]
-          logp += val['fn'].log_prob(val['value'])
+          
+          if not (key == 'theta' and score_type == 'conditional'):
+            logp += val['fn'].log_prob(val['value']).sum()
 
         sample = {'theta': model_trace['theta']['value'],
                   'y': model_trace['y']['value']}
-    
+
+
         return logp, sample
     
     # Split the key by batch

--- a/sbids/tasks/utils.py
+++ b/sbids/tasks/utils.py
@@ -35,7 +35,7 @@ def get_samples_and_scores(model, key, batch_size=64, score_type='density', thet
     keys = jax.random.split(key, batch_size)
 
     # Sample theta from the model
-    if thetas == None:
+    if thetas is None:
         thetas = jax.vmap(lambda k: trace(seed(model, k)).get_trace()['theta']['value'])(keys)
 
     return jax.vmap(jax.value_and_grad(log_prob_fn, has_aux=True))(thetas, keys)


### PR DESCRIPTION
I implemented the Galton Board task with numpyro and changed the function to get the simulations and the gradients so that it can used with all simulators. 
[In this notebook](https://github.com/Justinezgh/SBI-Diff-Simulator/blob/u/Justinezgh/galtonboard/notebooks/NumpyroGaltonBoard.ipynb) I check that the numpyro simulator is the same as the one used in the mining gold paper.